### PR TITLE
🧹 Refactor file classification logic in xprgen

### DIFF
--- a/build/vivado/bin/xprgen/main.go
+++ b/build/vivado/bin/xprgen/main.go
@@ -120,13 +120,15 @@ type FileLib struct {
 func AppendTo(systemVerilogFiles, verilogFiles, VHDLFiles, otherFiles *[]FileLib, fl FileLib) error {
 	if fl.Name == "" {
 		return fmt.Errorf("no file name in %+v", fl)
-	} else if strings.HasSuffix(fl.Name, SystemVerilogExtension) {
+	}
+	switch {
+	case strings.HasSuffix(fl.Name, SystemVerilogExtension):
 		*systemVerilogFiles = append(*systemVerilogFiles, fl)
-	} else if strings.HasSuffix(fl.Name, VerilogExtension) {
+	case strings.HasSuffix(fl.Name, VerilogExtension):
 		*verilogFiles = append(*verilogFiles, fl)
-	} else if strings.HasSuffix(fl.Name, VHDLExtension1) || strings.HasSuffix(fl.Name, VHDLExtension2) {
+	case strings.HasSuffix(fl.Name, VHDLExtension1), strings.HasSuffix(fl.Name, VHDLExtension2):
 		*VHDLFiles = append(*VHDLFiles, fl)
-	} else {
+	default:
 		*otherFiles = append(*otherFiles, fl)
 	}
 	return nil

--- a/build/vivado/bin/xprgen/main_test.go
+++ b/build/vivado/bin/xprgen/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAppendTo(t *testing.T) {
+	tests := []struct {
+		name               string
+		fl                 FileLib
+		initialSV          []FileLib
+		initialV           []FileLib
+		initialVHDL        []FileLib
+		initialOther       []FileLib
+		wantSV             []FileLib
+		wantV              []FileLib
+		wantVHDL           []FileLib
+		wantOther          []FileLib
+		wantErr            bool
+	}{
+		{
+			name: "SystemVerilog file",
+			fl:   FileLib{Name: "test.sv"},
+			wantSV: []FileLib{{Name: "test.sv"}},
+		},
+		{
+			name: "Verilog file",
+			fl:   FileLib{Name: "test.v"},
+			wantV: []FileLib{{Name: "test.v"}},
+		},
+		{
+			name: "VHDL file 1",
+			fl:   FileLib{Name: "test.vhd"},
+			wantVHDL: []FileLib{{Name: "test.vhd"}},
+		},
+		{
+			name: "VHDL file 2",
+			fl:   FileLib{Name: "test.vhdl"},
+			wantVHDL: []FileLib{{Name: "test.vhdl"}},
+		},
+		{
+			name: "Other file",
+			fl:   FileLib{Name: "test.txt"},
+			wantOther: []FileLib{{Name: "test.txt"}},
+		},
+		{
+			name:    "Empty filename",
+			fl:      FileLib{Name: ""},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sv := tt.initialSV
+			v := tt.initialV
+			vhdl := tt.initialVHDL
+			other := tt.initialOther
+
+			err := AppendTo(&sv, &v, &vhdl, &other, tt.fl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AppendTo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(sv, tt.wantSV) {
+				t.Errorf("AppendTo() sv = %v, want %v", sv, tt.wantSV)
+			}
+			if !reflect.DeepEqual(v, tt.wantV) {
+				t.Errorf("AppendTo() v = %v, want %v", v, tt.wantV)
+			}
+			if !reflect.DeepEqual(vhdl, tt.wantVHDL) {
+				t.Errorf("AppendTo() vhdl = %v, want %v", vhdl, tt.wantVHDL)
+			}
+			if !reflect.DeepEqual(other, tt.wantOther) {
+				t.Errorf("AppendTo() other = %v, want %v", other, tt.wantOther)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactored the `AppendTo` function in `build/vivado/bin/xprgen/main.go` by replacing a complex `if-else` chain with a cleaner and more idiomatic Go `switch` statement. The new implementation maintains exactly the same classification logic using `strings.HasSuffix`. Additionally, a comprehensive set of unit tests was added in `build/vivado/bin/xprgen/main_test.go` to ensure correctness and prevent future regressions.

🎯 **What:** The code health issue addressed was a repetitive and complex `if-else` chain used to classify different hardware design file types (SystemVerilog, Verilog, VHDL) based on their suffixes.
💡 **Why:** Switching to a `switch` statement makes the code easier to read and extend. It also clearly separates the logic for each file type and follows Go's idiomatic style for multi-way branching.
✅ **Verification:** A new unit test file was created, covering all branches of the logic, including error cases and edge cases for different extensions. The tests were executed and passed successfully.
✨ **Result:** The codebase is now more maintainable and contains a new test suite that provides confidence in the file classification process.

---
*PR created automatically by Jules for task [375585995148424743](https://jules.google.com/task/375585995148424743) started by @filmil*