### PR TITLE
🔒 Fix unvalidated input causing panic in genparams

### DIFF
--- a/bin/genparams/main.go
+++ b/bin/genparams/main.go
@@ -21,6 +21,9 @@ var _ flag.Value = (*KVList)(nil)
 func (self *KVList) Set(v string) error {
 	sp := strings.Split(v, " ")[0]
 	kv := strings.Split(sp, "=")
+	if len(kv) < 2 {
+		return fmt.Errorf("invalid format: expected KEY=VALUE, got %q", v)
+	}
 	k, v := kv[0], kv[1]
 	self.values = append(self.values, KV{Key: k, Value: v})
 	return nil

--- a/bin/genparams/main_test.go
+++ b/bin/genparams/main_test.go
@@ -4,6 +4,43 @@ import (
 	"testing"
 )
 
+func TestKVListSet(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "valid",
+			input:   "KEY=VALUE",
+			wantErr: false,
+		},
+		{
+			name:    "invalid - no equals",
+			input:   "KEY",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - empty",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "valid with space",
+			input:   "KEY=VALUE something else",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kvl := &KVList{}
+			if err := kvl.Set(tt.input); (err != nil) != tt.wantErr {
+				t.Errorf("KVList.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestKVListString(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
🎯 **What:** The `KVList.Set` method in `bin/genparams/main.go` was susceptible to an index out of bounds panic when processing input strings that do not contain an `=` character.
⚠️ **Risk:** This vulnerability could lead to a Denial of Service (DoS) by causing the `genparams` tool to crash unexpectedly when provided with malformed command-line arguments.
🛡️ **Solution:** Implemented a length check on the slice returned by `strings.Split` to ensure it contains at least two elements before attempting to access them. Added comprehensive unit tests to verify correct handling of various input scenarios.

---
*PR created automatically by Jules for task [9483620676604385934](https://jules.google.com/task/9483620676604385934) started by @filmil*