### PR TITLE
🔒 fix sensitive data exposure via env logging in proggen

### DIFF
--- a/build/vivado/bin/proggen/BUILD.bazel
+++ b/build/vivado/bin/proggen/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -9,6 +9,12 @@ go_library(
     srcs = ["main.go"],
     importpath = "cp/build/vivado/bin/proggen",
     visibility = ["//visibility:private"],
+)
+
+go_test(
+    name = "proggen_test",
+    srcs = ["main_test.go"],
+    embed = [":proggen_lib"],
 )
 
 go_binary(

--- a/build/vivado/bin/proggen/main.go
+++ b/build/vivado/bin/proggen/main.go
@@ -20,15 +20,7 @@ type Args struct {
 	ProgRunnerBinary string
 }
 
-func printEnv() {
-	for _, e := range os.Environ() {
-		log.Printf("env: %v", e)
-	}
-}
-
 func run(args Args) error {
-	printEnv()
-
 	if args.BitFile == "" {
 		return fmt.Errorf("param --bitfile is required.")
 	}

--- a/build/vivado/bin/proggen/main_test.go
+++ b/build/vivado/bin/proggen/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestRunDoesNotLogEnv(t *testing.T) {
+	var buf bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(oldOutput)
+
+	// Call run with minimal arguments. It will return an error because
+	// required fields are missing, but it should NOT have logged the environment.
+	_ = run(Args{})
+
+	output := buf.String()
+	if strings.Contains(output, "env: ") {
+		t.Errorf("Found sensitive environment data in logs: %q", output)
+	}
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the unredacted logging of all environment variables in the `proggen` utility.
⚠️ **Risk:** This could lead to sensitive data (like CI/CD secrets, API keys, or credentials) being exposed in build or execution logs, potentially allowing unauthorized access to other systems.
🛡️ **Solution:** Removed the `printEnv` function and its call in `build/vivado/bin/proggen/main.go`. Added a unit test in `build/vivado/bin/proggen/main_test.go` to ensure that environment variables are not logged during execution. Verified the fix by running all tests in the repository.

---
*PR created automatically by Jules for task [12771006821664066873](https://jules.google.com/task/12771006821664066873) started by @filmil*