### PR TITLE
🔒 [security fix] Remove sensitive environment variable logging in proggen

### DIFF
--- a/build/vivado/bin/proggen/main.go
+++ b/build/vivado/bin/proggen/main.go
@@ -20,15 +20,7 @@ type Args struct {
 	ProgRunnerBinary string
 }
 
-func printEnv() {
-	for _, e := range os.Environ() {
-		log.Printf("env: %v", e)
-	}
-}
-
 func run(args Args) error {
-	printEnv()
-
 	if args.BitFile == "" {
 		return fmt.Errorf("param --bitfile is required.")
 	}

--- a/build/vivado/bin/proggen/main_test.go
+++ b/build/vivado/bin/proggen/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRunRequiresArgs(t *testing.T) {
+	args := Args{}
+	err := run(args)
+	if err == nil {
+		t.Errorf("expected error when running with empty args, got nil")
+	}
+}
+
+func TestRunSuccess(t *testing.T) {
+	// Create dummy files for template and output
+	tplFile := "test.tpl"
+	outFile := "test.out"
+	defer os.Remove(tplFile)
+	defer os.Remove(outFile)
+
+	err := os.WriteFile(tplFile, []byte(`{{define "main_script.tpl.sh"}}test template{{end}}`), 0644)
+	if err != nil {
+		t.Fatalf("failed to create test template: %v", err)
+	}
+
+	args := Args{
+		BitFile:       "bit",
+		RunDockerFile: "docker",
+		GotoptFile:    "gotopt",
+		Outfile:       outFile,
+		TemplateFile:  tplFile,
+	}
+
+	err = run(args)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if _, err := os.Stat(outFile); os.IsNotExist(err) {
+		t.Errorf("expected outfile to be created")
+	}
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is sensitive environment variable exposure through logging.
⚠️ **Risk:** Potential exposure of secrets (credentials, API keys, etc.) to anyone with access to the logs.
🛡️ **Solution:** Removed the `printEnv` function and its invocation in the `run` function.


---
*PR created automatically by Jules for task [7612812919802774109](https://jules.google.com/task/7612812919802774109) started by @filmil*