### PR TITLE
🧹 Rename 'self' receiver to idiomatic 'l' in genparams

### DIFF
--- a/bin/genparams/main.go
+++ b/bin/genparams/main.go
@@ -18,17 +18,17 @@ type KVList struct {
 
 var _ flag.Value = (*KVList)(nil)
 
-func (self *KVList) Set(v string) error {
+func (l *KVList) Set(v string) error {
 	sp := strings.Split(v, " ")[0]
 	kv := strings.Split(sp, "=")
 	k, v := kv[0], kv[1]
-	self.values = append(self.values, KV{Key: k, Value: v})
+	l.values = append(l.values, KV{Key: k, Value: v})
 	return nil
 }
 
-func (self *KVList) String() string {
+func (l *KVList) String() string {
 	var out strings.Builder
-	for i, e := range self.values {
+	for i, e := range l.values {
 		if i > 0 {
 			out.WriteByte(';')
 		}
@@ -39,8 +39,8 @@ func (self *KVList) String() string {
 	return out.String()
 }
 
-func (self *KVList) Iter() []KV {
-	return self.values
+func (l *KVList) Iter() []KV {
+	return l.values
 }
 
 var (


### PR DESCRIPTION
🎯 **What**: Renamed the receiver name from `self` to the idiomatic `l` for the `KVList` type in `bin/genparams/main.go`.
💡 **Why**: In Go, it's idiomatic to use short, representative receiver names instead of generic names like `self` or `this`. This improves code readability and follows the Go community's best practices.
✅ **Verification**: Ran `go test ./bin/genparams/...` and all tests passed. Confirmed the change via code review.
✨ **Result**: The code in `bin/genparams/main.go` now adheres to Go's idiomatic receiver naming conventions.

---
*PR created automatically by Jules for task [13424858802519504814](https://jules.google.com/task/13424858802519504814) started by @filmil*