### PR TITLE
docs: generate markdown files for bzl rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ This project relies on an approach that executes Vivado tools within a Docker co
 
 It's important to note that distributing the Docker container itself is generally not feasible due to licensing and size, so you will need to build it locally. The setup of the required Vivado Docker image is handled by the `rules_vivado` project (https://github.com/agoessling/rules_vivado), which these rules depend upon. Please refer to their documentation for details on creating and installing the Vivado container.
 
+
+
+## Documentation
+
+* [doc.bzl documentation](doc.md)
+* [build/vivado/rules.bzl documentation](build/vivado/rules.md)
+* [internal/defines.bzl documentation](internal/defines.md)
+* [internal/providers.bzl documentation](internal/providers.md)
+
 ## Prior Art
 
 *   [agoessling/rules_vivado](https://github.com/agoessling/rules_vivado): This repository predates `bazel_rules_vivado`. It adopts a different approach, requiring a pre-installed Vivado instance rather than using a containerized version.

--- a/build/vivado/BUILD.bazel
+++ b/build/vivado/BUILD.bazel
@@ -1,5 +1,7 @@
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -45,4 +47,18 @@ bzl_library(
         "@bazel_skylib//lib:paths",
         #"@rules_bid//build:rules",
     ],
+)
+
+stardoc(
+    name = "md",
+    out = "gen.rules.md",
+    input = "rules.bzl",
+    deps = [":rules"],
+)
+
+write_source_files(
+    name = "update",
+    files = {
+        "rules.md": ":md",
+    },
 )

--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -1,0 +1,289 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="vivado_library"></a>
+
+## vivado_library
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_library")
+
+vivado_library(<a href="#vivado_library-name">name</a>, <a href="#vivado_library-deps">deps</a>, <a href="#vivado_library-srcs">srcs</a>, <a href="#vivado_library-data">data</a>, <a href="#vivado_library-hdrs">hdrs</a>, <a href="#vivado_library-defines">defines</a>, <a href="#vivado_library-env">env</a>, <a href="#vivado_library-includes">includes</a>, <a href="#vivado_library-library_name">library_name</a>, <a href="#vivado_library-mount">mount</a>, <a href="#vivado_library-standard">standard</a>,
+               <a href="#vivado_library-use_glbl">use_glbl</a>, <a href="#vivado_library-vhdl1993">vhdl1993</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_library-deps"></a>deps |  The list of files in this library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_library-srcs"></a>srcs |  The list of files in this library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_library-data"></a>data |  The list of target that should be available for compilation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_library-hdrs"></a>hdrs |  The list of include files in this library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_library-defines"></a>defines |  The list of key-to-value mappings to apply to the compilation   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_library-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_library-includes"></a>includes |  The list of additional directories to append to the include list   | List of strings | optional |  `[]`  |
+| <a id="vivado_library-library_name"></a>library_name |  An optional library name, in the case the target name can not be used for some reason.   | String | optional |  `""`  |
+| <a id="vivado_library-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_library-standard"></a>standard |  Specify the language standard to use   | String | optional |  `"2008"`  |
+| <a id="vivado_library-use_glbl"></a>use_glbl |  -   | Boolean | optional |  `False`  |
+| <a id="vivado_library-vhdl1993"></a>vhdl1993 |  Use VHDL-1993 standard else use VHDL-2008   | Boolean | optional |  `False`  |
+
+
+<a id="vivado_place_and_route"></a>
+
+## vivado_place_and_route
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_place_and_route")
+
+vivado_place_and_route(<a href="#vivado_place_and_route-name">name</a>, <a href="#vivado_place_and_route-env">env</a>, <a href="#vivado_place_and_route-mount">mount</a>, <a href="#vivado_place_and_route-synthesis">synthesis</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_place_and_route-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_place_and_route-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_place_and_route-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_place_and_route-synthesis"></a>synthesis |  The vivado synthesis to place and route   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+
+<a id="vivado_place_and_route2"></a>
+
+## vivado_place_and_route2
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_place_and_route2")
+
+vivado_place_and_route2(<a href="#vivado_place_and_route2-name">name</a>, <a href="#vivado_place_and_route2-env">env</a>, <a href="#vivado_place_and_route2-mount">mount</a>, <a href="#vivado_place_and_route2-synthesis">synthesis</a>, <a href="#vivado_place_and_route2-xdcs">xdcs</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_place_and_route2-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_place_and_route2-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_place_and_route2-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_place_and_route2-synthesis"></a>synthesis |  The mandatory synth2 target to use   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="vivado_place_and_route2-xdcs"></a>xdcs |  Constraint files   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+
+<a id="vivado_program_device"></a>
+
+## vivado_program_device
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_program_device")
+
+vivado_program_device(<a href="#vivado_program_device-name">name</a>, <a href="#vivado_program_device-deps">deps</a>, <a href="#vivado_program_device-data">data</a>, <a href="#vivado_program_device-prog_daemon">prog_daemon</a>, <a href="#vivado_program_device-prog_daemon_args">prog_daemon_args</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_program_device-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_program_device-deps"></a>deps |  The list of deps containing bitstream code   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_program_device-data"></a>data |  The list of dependencies to expand   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_program_device-prog_daemon"></a>prog_daemon |  The binary to start before programming   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_program_device-prog_daemon_args"></a>prog_daemon_args |  The args to give to prog_daemon, subject to make var substitution   | List of strings | optional |  `[]`  |
+
+
+<a id="vivado_project"></a>
+
+## vivado_project
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_project")
+
+vivado_project(<a href="#vivado_project-name">name</a>, <a href="#vivado_project-deps">deps</a>, <a href="#vivado_project-srcs">srcs</a>, <a href="#vivado_project-hdrs">hdrs</a>, <a href="#vivado_project-defines">defines</a>, <a href="#vivado_project-env">env</a>, <a href="#vivado_project-include_dirs">include_dirs</a>, <a href="#vivado_project-mount">mount</a>, <a href="#vivado_project-part">part</a>, <a href="#vivado_project-top_level">top_level</a>, <a href="#vivado_project-xdcs">xdcs</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_project-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_project-deps"></a>deps |  The list of library dependencies   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_project-srcs"></a>srcs |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_project-hdrs"></a>hdrs |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_project-defines"></a>defines |  -   | List of strings | optional |  `[]`  |
+| <a id="vivado_project-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_project-include_dirs"></a>include_dirs |  -   | List of strings | optional |  `[]`  |
+| <a id="vivado_project-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_project-part"></a>part |  The part that is targeted by this project   | String | required |  |
+| <a id="vivado_project-top_level"></a>top_level |  Top level entity name   | String | required |  |
+| <a id="vivado_project-xdcs"></a>xdcs |  A list of constraints files to use.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+
+<a id="vivado_simulation"></a>
+
+## vivado_simulation
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_simulation")
+
+vivado_simulation(<a href="#vivado_simulation-name">name</a>, <a href="#vivado_simulation-data">data</a>, <a href="#vivado_simulation-args">args</a>, <a href="#vivado_simulation-config">config</a>, <a href="#vivado_simulation-custom_tcl_script">custom_tcl_script</a>, <a href="#vivado_simulation-defines">defines</a>, <a href="#vivado_simulation-env">env</a>, <a href="#vivado_simulation-extra_modules">extra_modules</a>,
+                  <a href="#vivado_simulation-generic_tops">generic_tops</a>, <a href="#vivado_simulation-library">library</a>, <a href="#vivado_simulation-mount">mount</a>, <a href="#vivado_simulation-template">template</a>, <a href="#vivado_simulation-top">top</a>, <a href="#vivado_simulation-xelab_args">xelab_args</a>, <a href="#vivado_simulation-xelab_relaxed">xelab_relaxed</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_simulation-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_simulation-data"></a>data |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_simulation-args"></a>args |  Custom args to xsim   | List of strings | optional |  `[]`  |
+| <a id="vivado_simulation-config"></a>config |  If specified, the said named configuration will be selected (VHDL)   | String | optional |  `""`  |
+| <a id="vivado_simulation-custom_tcl_script"></a>custom_tcl_script |  Custom TCL script to run simulation with   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_simulation-defines"></a>defines |  The list of key-to-value mappings to apply to the compilation   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_simulation-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_simulation-extra_modules"></a>extra_modules |  Names of additional modules to co-simulate   | List of strings | optional |  `[]`  |
+| <a id="vivado_simulation-generic_tops"></a>generic_tops |  The list of key-to-value mappings to apply to the compilation   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_simulation-library"></a>library |  The library to run the simulation from   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_simulation-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_simulation-template"></a>template |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_vivado//build/vivado:xsim.tcl.template"`  |
+| <a id="vivado_simulation-top"></a>top |  Name of the top level entity to simulate   | String | optional |  `""`  |
+| <a id="vivado_simulation-xelab_args"></a>xelab_args |  Custom args to elaboration step   | List of strings | optional |  `[]`  |
+| <a id="vivado_simulation-xelab_relaxed"></a>xelab_relaxed |  Relax HDL checks, sometimes needed for Verilog modules   | Boolean | optional |  `False`  |
+
+
+<a id="vivado_synthesis"></a>
+
+## vivado_synthesis
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_synthesis")
+
+vivado_synthesis(<a href="#vivado_synthesis-name">name</a>, <a href="#vivado_synthesis-env">env</a>, <a href="#vivado_synthesis-mount">mount</a>, <a href="#vivado_synthesis-project">project</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_synthesis-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_synthesis-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis-project"></a>project |  The Vivado project to work on   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+
+<a id="vivado_synthesis2"></a>
+
+## vivado_synthesis2
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_synthesis2")
+
+vivado_synthesis2(<a href="#vivado_synthesis2-name">name</a>, <a href="#vivado_synthesis2-deps">deps</a>, <a href="#vivado_synthesis2-srcs">srcs</a>, <a href="#vivado_synthesis2-data">data</a>, <a href="#vivado_synthesis2-hdrs">hdrs</a>, <a href="#vivado_synthesis2-defines">defines</a>, <a href="#vivado_synthesis2-env">env</a>, <a href="#vivado_synthesis2-generics">generics</a>, <a href="#vivado_synthesis2-include_dirs">include_dirs</a>, <a href="#vivado_synthesis2-mount">mount</a>, <a href="#vivado_synthesis2-part">part</a>,
+                  <a href="#vivado_synthesis2-top">top</a>, <a href="#vivado_synthesis2-xdcs">xdcs</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_synthesis2-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_synthesis2-deps"></a>deps |  The sources for the libraries   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_synthesis2-srcs"></a>srcs |  The sources for the `work` library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_synthesis2-data"></a>data |  Other data   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_synthesis2-hdrs"></a>hdrs |  The headers for the `work` library if verilog   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_synthesis2-defines"></a>defines |  -   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-generics"></a>generics |  -   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-include_dirs"></a>include_dirs |  -   | List of strings | optional |  `[]`  |
+| <a id="vivado_synthesis2-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-part"></a>part |  The part that is targeted by this project   | String | required |  |
+| <a id="vivado_synthesis2-top"></a>top |  Mandatory name of the top level entity   | String | required |  |
+| <a id="vivado_synthesis2-xdcs"></a>xdcs |  Constraint files   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+
+<a id="vivado_unisims_library"></a>
+
+## vivado_unisims_library
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_unisims_library")
+
+vivado_unisims_library(<a href="#vivado_unisims_library-name">name</a>, <a href="#vivado_unisims_library-env">env</a>, <a href="#vivado_unisims_library-export_libraries">export_libraries</a>, <a href="#vivado_unisims_library-family">family</a>, <a href="#vivado_unisims_library-force">force</a>, <a href="#vivado_unisims_library-language">language</a>, <a href="#vivado_unisims_library-libraries">libraries</a>, <a href="#vivado_unisims_library-mount">mount</a>,
+                       <a href="#vivado_unisims_library-no_ip_compile">no_ip_compile</a>, <a href="#vivado_unisims_library-no_systemc_compile">no_systemc_compile</a>, <a href="#vivado_unisims_library-quiet">quiet</a>, <a href="#vivado_unisims_library-simulator">simulator</a>, <a href="#vivado_unisims_library-skip_libraries">skip_libraries</a>, <a href="#vivado_unisims_library-template">template</a>,
+                       <a href="#vivado_unisims_library-verbose">verbose</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_unisims_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_unisims_library-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_unisims_library-export_libraries"></a>export_libraries |  The libraries to make available to users.   | List of strings | optional |  `["unisim", "unimacro", "unifast"]`  |
+| <a id="vivado_unisims_library-family"></a>family |  The device family to compile the library for.   | String | optional |  `"artix7"`  |
+| <a id="vivado_unisims_library-force"></a>force |  -   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-language"></a>language |  The language to compile for: vhdl\|verilog\|all   | String | optional |  `"vhdl"`  |
+| <a id="vivado_unisims_library-libraries"></a>libraries |  The libraries to compile: unisim\|simprim\|...\|all   | List of strings | optional |  `["unisim"]`  |
+| <a id="vivado_unisims_library-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_unisims_library-no_ip_compile"></a>no_ip_compile |  -   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-no_systemc_compile"></a>no_systemc_compile |  -   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-quiet"></a>quiet |  -   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-simulator"></a>simulator |  Name of the top level entity to simulate   | String | optional |  `"xsim"`  |
+| <a id="vivado_unisims_library-skip_libraries"></a>skip_libraries |  The list of libraries NOT to compile   | List of strings | optional |  `[]`  |
+| <a id="vivado_unisims_library-template"></a>template |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_vivado//build/vivado:compile_simlib.tcl.template"`  |
+| <a id="vivado_unisims_library-verbose"></a>verbose |  -   | Boolean | optional |  `False`  |
+
+
+<a id="vivado_generics"></a>
+
+## vivado_generics
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_generics")
+
+vivado_generics(<a href="#vivado_generics-name">name</a>, <a href="#vivado_generics-verilog_top">verilog_top</a>, <a href="#vivado_generics-vhdl_top">vhdl_top</a>, <a href="#vivado_generics-params">params</a>, <a href="#vivado_generics-generics">generics</a>, <a href="#vivado_generics-data">data</a>, <a href="#vivado_generics-synth">synth</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="vivado_generics-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="vivado_generics-verilog_top"></a>verilog_top |  <p align="center"> - </p>   |  `None` |
+| <a id="vivado_generics-vhdl_top"></a>vhdl_top |  <p align="center"> - </p>   |  `None` |
+| <a id="vivado_generics-params"></a>params |  <p align="center"> - </p>   |  `{}` |
+| <a id="vivado_generics-generics"></a>generics |  <p align="center"> - </p>   |  `{}` |
+| <a id="vivado_generics-data"></a>data |  <p align="center"> - </p>   |  `None` |
+| <a id="vivado_generics-synth"></a>synth |  <p align="center"> - </p>   |  `None` |

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -6,6 +8,28 @@ bzl_library(
     name = "defines",
     srcs = ["defines.bzl"],
     deps = ["@rules_bid//build:rules"],
+)
+
+stardoc(
+    name = "md_defines",
+    out = "gen.defines.md",
+    input = "defines.bzl",
+    deps = [":defines"],
+)
+
+stardoc(
+    name = "md_providers",
+    out = "gen.providers.md",
+    input = "providers.bzl",
+    deps = [":providers"],
+)
+
+write_source_files(
+    name = "update",
+    files = {
+        "defines.md": ":md_defines",
+        "providers.md": ":md_providers",
+    },
 )
 
 bzl_library(

--- a/internal/defines.md
+++ b/internal/defines.md
@@ -1,0 +1,31 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="script_cmd"></a>
+
+## script_cmd
+
+<pre>
+load("@rules_vivado//internal:defines.bzl", "script_cmd")
+
+script_cmd(<a href="#script_cmd-script_path">script_path</a>, <a href="#script_cmd-dir_reference">dir_reference</a>, <a href="#script_cmd-cache_dir">cache_dir</a>, <a href="#script_cmd-source_dir">source_dir</a>, <a href="#script_cmd-mounts">mounts</a>, <a href="#script_cmd-envs">envs</a>, <a href="#script_cmd-tools">tools</a>, <a href="#script_cmd-freeargs">freeargs</a>,
+           <a href="#script_cmd-workdir_name">workdir_name</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="script_cmd-script_path"></a>script_path |  <p align="center"> - </p>   |  none |
+| <a id="script_cmd-dir_reference"></a>dir_reference |  <p align="center"> - </p>   |  none |
+| <a id="script_cmd-cache_dir"></a>cache_dir |  <p align="center"> - </p>   |  none |
+| <a id="script_cmd-source_dir"></a>source_dir |  <p align="center"> - </p>   |  `""` |
+| <a id="script_cmd-mounts"></a>mounts |  <p align="center"> - </p>   |  `None` |
+| <a id="script_cmd-envs"></a>envs |  <p align="center"> - </p>   |  `None` |
+| <a id="script_cmd-tools"></a>tools |  <p align="center"> - </p>   |  `None` |
+| <a id="script_cmd-freeargs"></a>freeargs |  <p align="center"> - </p>   |  `[]` |
+| <a id="script_cmd-workdir_name"></a>workdir_name |  <p align="center"> - </p>   |  `"/work"` |

--- a/internal/providers.md
+++ b/internal/providers.md
@@ -1,0 +1,102 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="VivadoBitstreamProvider"></a>
+
+## VivadoBitstreamProvider
+
+<pre>
+load("@rules_vivado//internal:providers.bzl", "VivadoBitstreamProvider")
+
+VivadoBitstreamProvider(<a href="#VivadoBitstreamProvider-bitstream">bitstream</a>)
+</pre>
+
+Information about the bitstream
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="VivadoBitstreamProvider-bitstream"></a>bitstream |  The bitstream to program into the FPGA    |
+
+
+<a id="VivadoGenProvider"></a>
+
+## VivadoGenProvider
+
+<pre>
+load("@rules_vivado//internal:providers.bzl", "VivadoGenProvider")
+
+VivadoGenProvider(<a href="#VivadoGenProvider-sources">sources</a>, <a href="#VivadoGenProvider-deps">deps</a>, <a href="#VivadoGenProvider-headers">headers</a>, <a href="#VivadoGenProvider-constraints">constraints</a>, <a href="#VivadoGenProvider-include_dirs">include_dirs</a>, <a href="#VivadoGenProvider-xpr_tcl_script">xpr_tcl_script</a>,
+                  <a href="#VivadoGenProvider-synth_tcl_script">synth_tcl_script</a>, <a href="#VivadoGenProvider-pnr_tcl_script">pnr_tcl_script</a>, <a href="#VivadoGenProvider-pgm_tcl_script">pgm_tcl_script</a>, <a href="#VivadoGenProvider-xpr_file">xpr_file</a>, <a href="#VivadoGenProvider-top_level">top_level</a>, <a href="#VivadoGenProvider-project_name">project_name</a>,
+                  <a href="#VivadoGenProvider-xpr_gen_output_dir">xpr_gen_output_dir</a>, <a href="#VivadoGenProvider-part">part</a>)
+</pre>
+
+Information about generated vivado files
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="VivadoGenProvider-sources"></a>sources |  The list of the module's source files    |
+| <a id="VivadoGenProvider-deps"></a>deps |  Libraries    |
+| <a id="VivadoGenProvider-headers"></a>headers |  A list of header files.  Headers are present in the sandbox, but not on the command line    |
+| <a id="VivadoGenProvider-constraints"></a>constraints |  The list of constraints files to use    |
+| <a id="VivadoGenProvider-include_dirs"></a>include_dirs |  A list of include directories for the code at hand    |
+| <a id="VivadoGenProvider-xpr_tcl_script"></a>xpr_tcl_script |  The TCL script used by vivado to generate a project file    |
+| <a id="VivadoGenProvider-synth_tcl_script"></a>synth_tcl_script |  The TCL script used to start synthesis    |
+| <a id="VivadoGenProvider-pnr_tcl_script"></a>pnr_tcl_script |  The TCL script used to start place and route    |
+| <a id="VivadoGenProvider-pgm_tcl_script"></a>pgm_tcl_script |  The TCL script used to start programming the device    |
+| <a id="VivadoGenProvider-xpr_file"></a>xpr_file |  The generated Vivado project file    |
+| <a id="VivadoGenProvider-top_level"></a>top_level |  The top level entity to process    |
+| <a id="VivadoGenProvider-project_name"></a>project_name |  The name of the project, after the target    |
+| <a id="VivadoGenProvider-xpr_gen_output_dir"></a>xpr_gen_output_dir |  The output directory from the xpr_gen step    |
+| <a id="VivadoGenProvider-part"></a>part |  The part designator that is being targeted in this project    |
+
+
+<a id="VivadoLibraryProvider"></a>
+
+## VivadoLibraryProvider
+
+<pre>
+load("@rules_vivado//internal:providers.bzl", "VivadoLibraryProvider")
+
+VivadoLibraryProvider(<a href="#VivadoLibraryProvider-name">name</a>, <a href="#VivadoLibraryProvider-files">files</a>, <a href="#VivadoLibraryProvider-hdrs">hdrs</a>, <a href="#VivadoLibraryProvider-includes">includes</a>, <a href="#VivadoLibraryProvider-deps">deps</a>, <a href="#VivadoLibraryProvider-deps_names">deps_names</a>, <a href="#VivadoLibraryProvider-library_dir">library_dir</a>, <a href="#VivadoLibraryProvider-unisims_libs">unisims_libs</a>)
+</pre>
+
+A library of files used for vivado
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="VivadoLibraryProvider-name"></a>name |  The library name    |
+| <a id="VivadoLibraryProvider-files"></a>files |  The list of files comprising this library    |
+| <a id="VivadoLibraryProvider-hdrs"></a>hdrs |  The list of headers in this library    |
+| <a id="VivadoLibraryProvider-includes"></a>includes |  The list of include dirs in this library.    |
+| <a id="VivadoLibraryProvider-deps"></a>deps |  A depset of other providers    |
+| <a id="VivadoLibraryProvider-deps_names"></a>deps_names |  A depset of library names contained in `deps`    |
+| <a id="VivadoLibraryProvider-library_dir"></a>library_dir |  A Vivado compiled library directory    |
+| <a id="VivadoLibraryProvider-unisims_libs"></a>unisims_libs |  A boolean    |
+
+
+<a id="VivadoSynthProvider"></a>
+
+## VivadoSynthProvider
+
+<pre>
+load("@rules_vivado//internal:providers.bzl", "VivadoSynthProvider")
+
+VivadoSynthProvider(<a href="#VivadoSynthProvider-synth_output_dir">synth_output_dir</a>, <a href="#VivadoSynthProvider-synth_xpr_file">synth_xpr_file</a>, <a href="#VivadoSynthProvider-synth_dcp_file">synth_dcp_file</a>)
+</pre>
+
+Information about the synthesis step
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="VivadoSynthProvider-synth_output_dir"></a>synth_output_dir |  -    |
+| <a id="VivadoSynthProvider-synth_xpr_file"></a>synth_xpr_file |  The XPR file after synthesis    |
+| <a id="VivadoSynthProvider-synth_dcp_file"></a>synth_dcp_file |  The DCP file of synthesis step    |


### PR DESCRIPTION
Added `stardoc` and `write_source_files` rules to `build/vivado/BUILD.bazel` and `internal/BUILD.bazel` in order to automatically generate markdown documentation (`rules.md`, `defines.md`, `providers.md`) from `.bzl` files, similarly to how it was done for `doc.bzl` in the root `BUILD.bazel`.

---
*PR created automatically by Jules for task [15364298563805643357](https://jules.google.com/task/15364298563805643357) started by @filmil*