### PR TITLE
chore: sync generated documentation files with starlark source

### DIFF
--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -1,6 +1,6 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-
+Vivado rules for Bazel.
 
 <a id="vivado_library"></a>
 
@@ -31,7 +31,7 @@ vivado_library(<a href="#vivado_library-name">name</a>, <a href="#vivado_library
 | <a id="vivado_library-library_name"></a>library_name |  An optional library name, in the case the target name can not be used for some reason.   | String | optional |  `""`  |
 | <a id="vivado_library-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_library-standard"></a>standard |  Specify the language standard to use   | String | optional |  `"2008"`  |
-| <a id="vivado_library-use_glbl"></a>use_glbl |  -   | Boolean | optional |  `False`  |
+| <a id="vivado_library-use_glbl"></a>use_glbl |  Whether to use the global glbl.v.   | Boolean | optional |  `False`  |
 | <a id="vivado_library-vhdl1993"></a>vhdl1993 |  Use VHDL-1993 standard else use VHDL-2008   | Boolean | optional |  `False`  |
 
 
@@ -125,11 +125,11 @@ vivado_project(<a href="#vivado_project-name">name</a>, <a href="#vivado_project
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="vivado_project-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="vivado_project-deps"></a>deps |  The list of library dependencies   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vivado_project-srcs"></a>srcs |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vivado_project-hdrs"></a>hdrs |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vivado_project-defines"></a>defines |  -   | List of strings | optional |  `[]`  |
+| <a id="vivado_project-srcs"></a>srcs |  A list of source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_project-hdrs"></a>hdrs |  A list of header files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_project-defines"></a>defines |  A list of defines.   | List of strings | optional |  `[]`  |
 | <a id="vivado_project-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
-| <a id="vivado_project-include_dirs"></a>include_dirs |  -   | List of strings | optional |  `[]`  |
+| <a id="vivado_project-include_dirs"></a>include_dirs |  A list of include directories.   | List of strings | optional |  `[]`  |
 | <a id="vivado_project-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_project-part"></a>part |  The part that is targeted by this project   | String | required |  |
 | <a id="vivado_project-top_level"></a>top_level |  Top level entity name   | String | required |  |
@@ -155,7 +155,7 @@ vivado_simulation(<a href="#vivado_simulation-name">name</a>, <a href="#vivado_s
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="vivado_simulation-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vivado_simulation-data"></a>data |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_simulation-data"></a>data |  A list of data targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="vivado_simulation-args"></a>args |  Custom args to xsim   | List of strings | optional |  `[]`  |
 | <a id="vivado_simulation-config"></a>config |  If specified, the said named configuration will be selected (VHDL)   | String | optional |  `""`  |
 | <a id="vivado_simulation-custom_tcl_script"></a>custom_tcl_script |  Custom TCL script to run simulation with   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
@@ -165,7 +165,7 @@ vivado_simulation(<a href="#vivado_simulation-name">name</a>, <a href="#vivado_s
 | <a id="vivado_simulation-generic_tops"></a>generic_tops |  The list of key-to-value mappings to apply to the compilation   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_simulation-library"></a>library |  The library to run the simulation from   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vivado_simulation-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
-| <a id="vivado_simulation-template"></a>template |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_vivado//build/vivado:xsim.tcl.template"`  |
+| <a id="vivado_simulation-template"></a>template |  The TCL template to run.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_vivado//build/vivado:xsim.tcl.template"`  |
 | <a id="vivado_simulation-top"></a>top |  Name of the top level entity to simulate   | String | optional |  `""`  |
 | <a id="vivado_simulation-xelab_args"></a>xelab_args |  Custom args to elaboration step   | List of strings | optional |  `[]`  |
 | <a id="vivado_simulation-xelab_relaxed"></a>xelab_relaxed |  Relax HDL checks, sometimes needed for Verilog modules   | Boolean | optional |  `False`  |
@@ -217,10 +217,10 @@ vivado_synthesis2(<a href="#vivado_synthesis2-name">name</a>, <a href="#vivado_s
 | <a id="vivado_synthesis2-srcs"></a>srcs |  The sources for the `work` library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="vivado_synthesis2-data"></a>data |  Other data   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="vivado_synthesis2-hdrs"></a>hdrs |  The headers for the `work` library if verilog   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vivado_synthesis2-defines"></a>defines |  -   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-defines"></a>defines |  A dictionary of defines.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_synthesis2-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
-| <a id="vivado_synthesis2-generics"></a>generics |  -   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
-| <a id="vivado_synthesis2-include_dirs"></a>include_dirs |  -   | List of strings | optional |  `[]`  |
+| <a id="vivado_synthesis2-generics"></a>generics |  A dictionary of generics.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-include_dirs"></a>include_dirs |  A list of include directories.   | List of strings | optional |  `[]`  |
 | <a id="vivado_synthesis2-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_synthesis2-part"></a>part |  The part that is targeted by this project   | String | required |  |
 | <a id="vivado_synthesis2-top"></a>top |  Mandatory name of the top level entity   | String | required |  |
@@ -250,17 +250,17 @@ vivado_unisims_library(<a href="#vivado_unisims_library-name">name</a>, <a href=
 | <a id="vivado_unisims_library-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_unisims_library-export_libraries"></a>export_libraries |  The libraries to make available to users.   | List of strings | optional |  `["unisim", "unimacro", "unifast"]`  |
 | <a id="vivado_unisims_library-family"></a>family |  The device family to compile the library for.   | String | optional |  `"artix7"`  |
-| <a id="vivado_unisims_library-force"></a>force |  -   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-force"></a>force |  Whether to force compilation.   | Boolean | optional |  `False`  |
 | <a id="vivado_unisims_library-language"></a>language |  The language to compile for: vhdl\|verilog\|all   | String | optional |  `"vhdl"`  |
 | <a id="vivado_unisims_library-libraries"></a>libraries |  The libraries to compile: unisim\|simprim\|...\|all   | List of strings | optional |  `["unisim"]`  |
 | <a id="vivado_unisims_library-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
-| <a id="vivado_unisims_library-no_ip_compile"></a>no_ip_compile |  -   | Boolean | optional |  `False`  |
-| <a id="vivado_unisims_library-no_systemc_compile"></a>no_systemc_compile |  -   | Boolean | optional |  `False`  |
-| <a id="vivado_unisims_library-quiet"></a>quiet |  -   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-no_ip_compile"></a>no_ip_compile |  Whether to skip IP compile.   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-no_systemc_compile"></a>no_systemc_compile |  Whether to skip SystemC compile.   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-quiet"></a>quiet |  Whether to be quiet.   | Boolean | optional |  `False`  |
 | <a id="vivado_unisims_library-simulator"></a>simulator |  Name of the top level entity to simulate   | String | optional |  `"xsim"`  |
 | <a id="vivado_unisims_library-skip_libraries"></a>skip_libraries |  The list of libraries NOT to compile   | List of strings | optional |  `[]`  |
-| <a id="vivado_unisims_library-template"></a>template |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_vivado//build/vivado:compile_simlib.tcl.template"`  |
-| <a id="vivado_unisims_library-verbose"></a>verbose |  -   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-template"></a>template |  The TCL template to run.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_vivado//build/vivado:compile_simlib.tcl.template"`  |
+| <a id="vivado_unisims_library-verbose"></a>verbose |  Whether to be verbose.   | Boolean | optional |  `False`  |
 
 
 <a id="vivado_generics"></a>
@@ -273,17 +273,17 @@ load("@rules_vivado//build/vivado:rules.bzl", "vivado_generics")
 vivado_generics(<a href="#vivado_generics-name">name</a>, <a href="#vivado_generics-verilog_top">verilog_top</a>, <a href="#vivado_generics-vhdl_top">vhdl_top</a>, <a href="#vivado_generics-params">params</a>, <a href="#vivado_generics-generics">generics</a>, <a href="#vivado_generics-data">data</a>, <a href="#vivado_generics-synth">synth</a>)
 </pre>
 
-
+Generates TCL scripts for generics/parameters.
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="vivado_generics-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="vivado_generics-verilog_top"></a>verilog_top |  <p align="center"> - </p>   |  `None` |
-| <a id="vivado_generics-vhdl_top"></a>vhdl_top |  <p align="center"> - </p>   |  `None` |
-| <a id="vivado_generics-params"></a>params |  <p align="center"> - </p>   |  `{}` |
-| <a id="vivado_generics-generics"></a>generics |  <p align="center"> - </p>   |  `{}` |
-| <a id="vivado_generics-data"></a>data |  <p align="center"> - </p>   |  `None` |
-| <a id="vivado_generics-synth"></a>synth |  <p align="center"> - </p>   |  `None` |
+| <a id="vivado_generics-name"></a>name |  Target name.   |  none |
+| <a id="vivado_generics-verilog_top"></a>verilog_top |  Verilog top entity.   |  `None` |
+| <a id="vivado_generics-vhdl_top"></a>vhdl_top |  VHDL top entity.   |  `None` |
+| <a id="vivado_generics-params"></a>params |  Dictionary of parameters.   |  `{}` |
+| <a id="vivado_generics-generics"></a>generics |  Dictionary of generics.   |  `{}` |
+| <a id="vivado_generics-data"></a>data |  Data targets.   |  `None` |
+| <a id="vivado_generics-synth"></a>synth |  Synthesis target.   |  `None` |

--- a/doc.md
+++ b/doc.md
@@ -1,6 +1,6 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-
+Module providing documentation helper functions.
 
 <a id="script_cmd"></a>
 
@@ -13,21 +13,25 @@ script_cmd(<a href="#script_cmd-script_path">script_path</a>, <a href="#script_c
            <a href="#script_cmd-workdir_name">workdir_name</a>)
 </pre>
 
-
+Generates the command line to run a docker container.
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="script_cmd-script_path"></a>script_path |  <p align="center"> - </p>   |  none |
-| <a id="script_cmd-dir_reference"></a>dir_reference |  <p align="center"> - </p>   |  none |
-| <a id="script_cmd-cache_dir"></a>cache_dir |  <p align="center"> - </p>   |  none |
-| <a id="script_cmd-source_dir"></a>source_dir |  <p align="center"> - </p>   |  `""` |
-| <a id="script_cmd-mounts"></a>mounts |  <p align="center"> - </p>   |  `None` |
-| <a id="script_cmd-envs"></a>envs |  <p align="center"> - </p>   |  `None` |
-| <a id="script_cmd-tools"></a>tools |  <p align="center"> - </p>   |  `None` |
-| <a id="script_cmd-freeargs"></a>freeargs |  <p align="center"> - </p>   |  `[]` |
-| <a id="script_cmd-workdir_name"></a>workdir_name |  <p align="center"> - </p>   |  `"/work"` |
+| <a id="script_cmd-script_path"></a>script_path |  Path to the docker run script.   |  none |
+| <a id="script_cmd-dir_reference"></a>dir_reference |  Directory reference.   |  none |
+| <a id="script_cmd-cache_dir"></a>cache_dir |  Cache directory.   |  none |
+| <a id="script_cmd-source_dir"></a>source_dir |  Source directory.   |  `""` |
+| <a id="script_cmd-mounts"></a>mounts |  Mounts to add.   |  `None` |
+| <a id="script_cmd-envs"></a>envs |  Environment variables to add.   |  `None` |
+| <a id="script_cmd-tools"></a>tools |  Tools to add.   |  `None` |
+| <a id="script_cmd-freeargs"></a>freeargs |  Additional arguments to pass.   |  `[]` |
+| <a id="script_cmd-workdir_name"></a>workdir_name |  The working directory name.   |  `"/work"` |
+
+**RETURNS**
+
+The generated command line as a string.
 
 

--- a/internal/defines.md
+++ b/internal/defines.md
@@ -1,6 +1,6 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-
+Defines variables and functions used in Vivado rules.
 
 <a id="script_cmd"></a>
 
@@ -13,19 +13,23 @@ script_cmd(<a href="#script_cmd-script_path">script_path</a>, <a href="#script_c
            <a href="#script_cmd-workdir_name">workdir_name</a>)
 </pre>
 
-
+Generates the command line to run a docker container.
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="script_cmd-script_path"></a>script_path |  <p align="center"> - </p>   |  none |
-| <a id="script_cmd-dir_reference"></a>dir_reference |  <p align="center"> - </p>   |  none |
-| <a id="script_cmd-cache_dir"></a>cache_dir |  <p align="center"> - </p>   |  none |
-| <a id="script_cmd-source_dir"></a>source_dir |  <p align="center"> - </p>   |  `""` |
-| <a id="script_cmd-mounts"></a>mounts |  <p align="center"> - </p>   |  `None` |
-| <a id="script_cmd-envs"></a>envs |  <p align="center"> - </p>   |  `None` |
-| <a id="script_cmd-tools"></a>tools |  <p align="center"> - </p>   |  `None` |
-| <a id="script_cmd-freeargs"></a>freeargs |  <p align="center"> - </p>   |  `[]` |
-| <a id="script_cmd-workdir_name"></a>workdir_name |  <p align="center"> - </p>   |  `"/work"` |
+| <a id="script_cmd-script_path"></a>script_path |  Path to the docker run script.   |  none |
+| <a id="script_cmd-dir_reference"></a>dir_reference |  Directory reference.   |  none |
+| <a id="script_cmd-cache_dir"></a>cache_dir |  Cache directory.   |  none |
+| <a id="script_cmd-source_dir"></a>source_dir |  Source directory.   |  `""` |
+| <a id="script_cmd-mounts"></a>mounts |  Mounts to add.   |  `None` |
+| <a id="script_cmd-envs"></a>envs |  Environment variables to add.   |  `None` |
+| <a id="script_cmd-tools"></a>tools |  Tools to add.   |  `None` |
+| <a id="script_cmd-freeargs"></a>freeargs |  Additional arguments to pass.   |  `[]` |
+| <a id="script_cmd-workdir_name"></a>workdir_name |  The working directory name.   |  `"/work"` |
+
+**RETURNS**
+
+The generated command line as a string.

--- a/internal/providers.md
+++ b/internal/providers.md
@@ -1,6 +1,6 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-
+Defines providers used in Vivado rules.
 
 <a id="VivadoBitstreamProvider"></a>
 
@@ -40,7 +40,7 @@ Information about generated vivado files
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="VivadoGenProvider-sources"></a>sources |  The list of the module's source files    |
-| <a id="VivadoGenProvider-deps"></a>deps |  Libraries    |
+| <a id="VivadoGenProvider-deps"></a>deps |  The list of library dependencies    |
 | <a id="VivadoGenProvider-headers"></a>headers |  A list of header files.  Headers are present in the sandbox, but not on the command line    |
 | <a id="VivadoGenProvider-constraints"></a>constraints |  The list of constraints files to use    |
 | <a id="VivadoGenProvider-include_dirs"></a>include_dirs |  A list of include directories for the code at hand    |
@@ -78,7 +78,7 @@ A library of files used for vivado
 | <a id="VivadoLibraryProvider-deps"></a>deps |  A depset of other providers    |
 | <a id="VivadoLibraryProvider-deps_names"></a>deps_names |  A depset of library names contained in `deps`    |
 | <a id="VivadoLibraryProvider-library_dir"></a>library_dir |  A Vivado compiled library directory    |
-| <a id="VivadoLibraryProvider-unisims_libs"></a>unisims_libs |  A boolean    |
+| <a id="VivadoLibraryProvider-unisims_libs"></a>unisims_libs |  A boolean indicating if this library contains UNISIMs    |
 
 
 <a id="VivadoSynthProvider"></a>
@@ -97,6 +97,6 @@ Information about the synthesis step
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="VivadoSynthProvider-synth_output_dir"></a>synth_output_dir |  -    |
+| <a id="VivadoSynthProvider-synth_output_dir"></a>synth_output_dir |  The output directory for the synthesis step    |
 | <a id="VivadoSynthProvider-synth_xpr_file"></a>synth_xpr_file |  The XPR file after synthesis    |
 | <a id="VivadoSynthProvider-synth_dcp_file"></a>synth_dcp_file |  The DCP file of synthesis step    |


### PR DESCRIPTION
chore: sync generated documentation files with starlark source

Updates the generated Markdown documentation files (`build/vivado/rules.md`, `doc.md`, `internal/defines.md`, `internal/providers.md`) to reflect the latest changes in the Starlark source code. This fixes the CI test failures in the `update_test` targets.

---
*PR created automatically by Jules for task [9703724684570374014](https://jules.google.com/task/9703724684570374014) started by @filmil*