### PR TITLE
fix: enable debug info for xsim and sync docs

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -131,7 +131,6 @@
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/source.json": "d8b5fe461272018cc07cfafce11fe369c7525330804c37eec5a82f84cd475366",
-    "https://bcr.bazel.build/modules/rules_bid/2.2.0/MODULE.bazel": "not found",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
@@ -246,9 +245,7 @@
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/bazel_registry.json": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/MODULE.bazel": "2c071c86fb07fc4dda1d12b3ede8bac669d6be58f9251ce158b37253d5fa2c0d",
-    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/source.json": "40672e459b4f82fca2539b4f4f8d35750eb6194430ac6f1ed5d311a82cac343c",
-    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_bid/2.2.0/MODULE.bazel": "15caebb3485cfe01409299e37dba17142ad4e783ffe6b75dd3b813b7488b26ec",
-    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_bid/2.2.0/source.json": "74063d77fd04dca1bc333ab6a0324b6273995fe5c99f3f25dd360105874caad1"
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/source.json": "40672e459b4f82fca2539b4f4f8d35750eb6194430ac6f1ed5d311a82cac343c"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {

--- a/build/vivado/rules.bzl
+++ b/build/vivado/rules.bzl
@@ -1569,7 +1569,7 @@ def _vivado_simulation_impl(ctx):
     Returns:
       A list of providers, including DefaultInfo and OutputGroupInfo.
     """
-    args = []
+    args = ["-debug", "typical"]
     args += ctx.attr.xelab_args
     files = []
     # elaborate first

--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -287,3 +287,5 @@ Generates TCL scripts for generics/parameters.
 | <a id="vivado_generics-generics"></a>generics |  Dictionary of generics.   |  `{}` |
 | <a id="vivado_generics-data"></a>data |  Data targets.   |  `None` |
 | <a id="vivado_generics-synth"></a>synth |  Synthesis target.   |  `None` |
+
+

--- a/internal/defines.md
+++ b/internal/defines.md
@@ -33,3 +33,5 @@ Generates the command line to run a docker container.
 **RETURNS**
 
 The generated command line as a string.
+
+

--- a/internal/providers.md
+++ b/internal/providers.md
@@ -100,3 +100,5 @@ Information about the synthesis step
 | <a id="VivadoSynthProvider-synth_output_dir"></a>synth_output_dir |  The output directory for the synthesis step    |
 | <a id="VivadoSynthProvider-synth_xpr_file"></a>synth_xpr_file |  The XPR file after synthesis    |
 | <a id="VivadoSynthProvider-synth_dcp_file"></a>synth_dcp_file |  The DCP file of synthesis step    |
+
+


### PR DESCRIPTION
This PR fixes test failures by enabling debug information for xsim simulations and syncing the generated documentation.

### Changes:
- Modified `build/vivado/rules.bzl` to include `-debug typical` in default `xelab` arguments.
- Updated `build/vivado/rules.md`, `internal/defines.md`, and `internal/providers.md` to match the source.
- Updated `MODULE.bazel.lock`.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt: run "bazel test //..." and fix errors; create and send PR once done