### PR TITLE
feat: add GitHub Actions workflow status badges to README

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -131,6 +131,7 @@
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/source.json": "d8b5fe461272018cc07cfafce11fe369c7525330804c37eec5a82f84cd475366",
+    "https://bcr.bazel.build/modules/rules_bid/2.2.0/MODULE.bazel": "not found",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
@@ -245,7 +246,9 @@
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/bazel_registry.json": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/MODULE.bazel": "2c071c86fb07fc4dda1d12b3ede8bac669d6be58f9251ce158b37253d5fa2c0d",
-    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/source.json": "40672e459b4f82fca2539b4f4f8d35750eb6194430ac6f1ed5d311a82cac343c"
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/source.json": "40672e459b4f82fca2539b4f4f8d35750eb6194430ac6f1ed5d311a82cac343c",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_bid/2.2.0/MODULE.bazel": "15caebb3485cfe01409299e37dba17142ad4e783ffe6b75dd3b813b7488b26ec",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_bid/2.2.0/source.json": "74063d77fd04dca1bc333ab6a0324b6273995fe5c99f3f25dd360105874caad1"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # bazel_rules_vivado: Xilinx Vivado Rules for Bazel
 
+[![Test](https://github.com/filmil/bazel_rules_vivado/actions/workflows/test.yml/badge.svg)](https://github.com/filmil/bazel_rules_vivado/actions/workflows/test.yml)
+[![Publish to my Bazel registry](https://github.com/filmil/bazel_rules_vivado/actions/workflows/publish.yml/badge.svg)](https://github.com/filmil/bazel_rules_vivado/actions/workflows/publish.yml)
+[![Publish on Bazel Central Registry](https://github.com/filmil/bazel_rules_vivado/actions/workflows/publish-bcr.yml/badge.svg)](https://github.com/filmil/bazel_rules_vivado/actions/workflows/publish-bcr.yml)
+[![Tag and Release](https://github.com/filmil/bazel_rules_vivado/actions/workflows/tag-and-release.yml/badge.svg)](https://github.com/filmil/bazel_rules_vivado/actions/workflows/tag-and-release.yml)
+
 ## Overview
 
 `bazel_rules_vivado` provides Bazel rules for building Xilinx Vivado projects. This allows for a portable and ephemeral Vivado installation to be used within your Bazel builds.


### PR DESCRIPTION
Adds status badges for all defined GitHub workflows to the README.md file. This provides better visibility into the build, publish, and release status of the project.

Fixes an issue where users would have to manually check the Actions tab to see the CI status.

---
*PR created automatically by Jules for task [13788488643236165252](https://jules.google.com/task/13788488643236165252) started by @filmil*