### PR TITLE
🧪 [testing improvement] Add test for WriteFile template execution error

### DIFF
--- a/build/vivado/bin/xprgen/main_test.go
+++ b/build/vivado/bin/xprgen/main_test.go
@@ -118,6 +118,7 @@ func TestWriteFile(t *testing.T) {
 	tests := []struct {
 		name    string
 		fn      string
+		tpl     *template.Template
 		xpr     *XPRBinding
 		wantErr bool
 		wantStr string
@@ -139,11 +140,22 @@ func TestWriteFile(t *testing.T) {
 			fn:   filepath.Join(tmpDir, "nonexistent", "out.txt"),
 			wantErr: true,
 		},
+		{
+			name: "template execution error",
+			fn:   filepath.Join(tmpDir, "error.txt"),
+			tpl:  template.Must(template.New("error").Option("missingkey=error").Parse("{{.NonExistent}}")),
+			xpr:  &XPRBinding{Project: "TestProj"},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := WriteFile(tt.fn, tpl, tt.xpr)
+			currTpl := tpl
+			if tt.tpl != nil {
+				currTpl = tt.tpl
+			}
+			err := WriteFile(tt.fn, currTpl, tt.xpr)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("WriteFile() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing coverage for template execution errors in the `WriteFile` function.
📊 **Coverage:** A new test case "template execution error" was added to `TestWriteFile`. It uses a template with `missingkey=error` and a data model that lacks the expected field.
✨ **Result:** Improved reliability of the `xprgen` tool by ensuring that template execution failures are correctly detected and reported as errors.

---
*PR created automatically by Jules for task [18079645996978053105](https://jules.google.com/task/18079645996978053105) started by @filmil*