### PR TITLE
feat: add vivado_repl rule to start vivado in tcl repl

### DIFF
--- a/build/vivado/BUILD.bazel
+++ b/build/vivado/BUILD.bazel
@@ -52,7 +52,14 @@ bzl_library(
         "//internal:vivado_simulation",
         "//internal:vivado_unisims_library",
         "//internal:vivado_generics",
+        "//internal:vivado_repl",
     ],
+)
+
+load(":rules.bzl", "vivado_repl")
+
+vivado_repl(
+    name = "repl",
 )
 
 stardoc(

--- a/build/vivado/rules.bzl
+++ b/build/vivado/rules.bzl
@@ -10,6 +10,7 @@ load("//internal:vivado_library.bzl", _vivado_library = "vivado_library")
 load("//internal:vivado_simulation.bzl", _vivado_simulation = "vivado_simulation")
 load("//internal:vivado_unisims_library.bzl", _vivado_unisims_library = "vivado_unisims_library")
 load("//internal:vivado_generics.bzl", _vivado_generics = "vivado_generics")
+load("//internal:vivado_repl.bzl", _vivado_repl = "vivado_repl")
 
 vivado_project = _vivado_project
 vivado_synthesis = _vivado_synthesis
@@ -21,3 +22,4 @@ vivado_library = _vivado_library
 vivado_simulation = _vivado_simulation
 vivado_unisims_library = _vivado_unisims_library
 vivado_generics = _vivado_generics
+vivado_repl = _vivado_repl

--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -136,6 +136,28 @@ vivado_project(<a href="#vivado_project-name">name</a>, <a href="#vivado_project
 | <a id="vivado_project-xdcs"></a>xdcs |  A list of constraints files to use.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 
 
+<a id="vivado_repl"></a>
+
+## vivado_repl
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_repl")
+
+vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_repl-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_repl-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_repl-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+
+
 <a id="vivado_simulation"></a>
 
 ## vivado_simulation

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -101,6 +101,14 @@ bzl_library(
     srcs = ["vivado_generics.bzl"],
 )
 
+bzl_library(
+    name = "vivado_repl",
+    srcs = ["vivado_repl.bzl"],
+    deps = [
+        ":defines",
+    ],
+)
+
 stardoc(
     name = "md_defines",
     out = "gen.defines.md",

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -4,6 +4,8 @@ load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["vivado_repl.sh.tpl"])
+
 bzl_library(
     name = "defines",
     srcs = ["defines.bzl"],
@@ -123,10 +125,18 @@ stardoc(
     deps = [":providers"],
 )
 
+stardoc(
+    name = "md_vivado_repl",
+    out = "gen.vivado_repl.md",
+    input = "vivado_repl.bzl",
+    deps = [":vivado_repl"],
+)
+
 write_source_files(
     name = "update",
     files = {
         "defines.md": ":md_defines",
         "providers.md": ":md_providers",
+        "vivado_repl.md": ":md_vivado_repl",
     },
 )

--- a/internal/vivado_repl.bzl
+++ b/internal/vivado_repl.bzl
@@ -1,0 +1,106 @@
+"""Vivado REPL rule."""
+
+load("//internal:defines.bzl",
+    "VIVADO_PATH",
+    "DOCKER_RUN_SCRIPT_ATTRS",
+    _script_cmd = "script_cmd",
+)
+
+def _vivado_repl_impl(ctx):
+    """Implementation for the vivado_repl rule.
+
+    Args:
+      ctx: The rule context.
+
+    Returns:
+      A DefaultInfo provider.
+    """
+    executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+
+    docker_run = ctx.executable._script
+
+    # We use rlocation to find the docker_run script at runtime.
+    # For external repositories, the rlocation path is usually <repo_name>/<path>.
+    # rules_bid is the repo name.
+    docker_run_rlocation = "rules_bid/build/docker_run"
+
+    # Generate the command using the helper.
+    # We'll use a placeholder for the script path and replace it in the bash script.
+    cmd = _script_cmd(
+        script_path = "DOCKER_RUN_PLACEHOLDER",
+        dir_reference = ".",
+        cache_dir = ".vivado_repl_cache",
+        freeargs = ["-it", "--net=host", "-e", "HOME=/work"],
+    )
+
+    script_content = """#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+if [[ ! -d "${{RUNFILES_DIR:-/dev/null}}" && ! -f "${{RUNFILES_MANIFEST_FILE:-/dev/null}}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${{RUNFILES_DIR:-/dev/null}}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${{RUNFILES_DIR}}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${{RUNFILES_MANIFEST_FILE:-/dev/null}}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \\
+            "${{RUNFILES_MANIFEST_FILE}}" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+set -eo pipefail
+
+DOCKER_RUN=$(rlocation {docker_run_rlocation})
+
+if [[ ! -f "${{DOCKER_RUN}}" ]]; then
+  echo >&2 "ERROR: cannot find docker_run at ${{DOCKER_RUN}}"
+  exit 1
+fi
+
+# Replace the placeholder with the actual path.
+CMD="{cmd}"
+CMD_FINAL="${{CMD/DOCKER_RUN_PLACEHOLDER/${{DOCKER_RUN}}}}"
+
+${{CMD_FINAL}} \\
+    LD_LIBRARY_PATH="{vivado_path}/lib/lnx64.o" \\
+    "{vivado_path}/bin/setEnvAndRunCmd.sh vivado" \\
+    -mode tcl "$@"
+""".format(
+        docker_run_rlocation = docker_run_rlocation,
+        cmd = cmd,
+        vivado_path = VIVADO_PATH,
+    )
+
+    ctx.actions.write(
+        output = executable,
+        content = script_content,
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = ctx.runfiles(files = [
+                docker_run,
+            ]).merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles),
+        ),
+    ]
+
+vivado_repl = rule(
+    implementation = _vivado_repl_impl,
+    executable = True,
+    attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+        "_bash_runfiles": attr.label(
+            default = "@bazel_tools//tools/bash/runfiles",
+        ),
+    },
+)

--- a/internal/vivado_repl.bzl
+++ b/internal/vivado_repl.bzl
@@ -16,14 +16,14 @@ def _vivado_repl_impl(ctx):
       A DefaultInfo provider.
     """
     executable = ctx.actions.declare_file(ctx.label.name + ".sh")
-
+    
     docker_run = ctx.executable._script
-
+    
     # We use rlocation to find the docker_run script at runtime.
     # For external repositories, the rlocation path is usually <repo_name>/<path>.
     # rules_bid is the repo name.
     docker_run_rlocation = "rules_bid/build/docker_run"
-
+    
     # Generate the command using the helper.
     # We'll use a placeholder for the script path and replace it in the bash script.
     cmd = _script_cmd(
@@ -32,57 +32,15 @@ def _vivado_repl_impl(ctx):
         cache_dir = ".vivado_repl_cache",
         freeargs = ["-it", "--net=host", "-e", "HOME=/work"],
     )
-
-    script_content = """#!/usr/bin/env bash
-
-# --- begin runfiles.bash initialization ---
-# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
-if [[ ! -d "${{RUNFILES_DIR:-/dev/null}}" && ! -f "${{RUNFILES_MANIFEST_FILE:-/dev/null}}" ]]; then
-  if [[ -f "$0.runfiles_manifest" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-    export RUNFILES_DIR="$0.runfiles"
-  fi
-fi
-if [[ -f "${{RUNFILES_DIR:-/dev/null}}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${{RUNFILES_DIR}}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${{RUNFILES_MANIFEST_FILE:-/dev/null}}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \\
-            "${{RUNFILES_MANIFEST_FILE}}" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
-
-set -eo pipefail
-
-DOCKER_RUN=$(rlocation {docker_run_rlocation})
-
-if [[ ! -f "${{DOCKER_RUN}}" ]]; then
-  echo >&2 "ERROR: cannot find docker_run at ${{DOCKER_RUN}}"
-  exit 1
-fi
-
-# Replace the placeholder with the actual path.
-CMD="{cmd}"
-CMD_FINAL="${{CMD/DOCKER_RUN_PLACEHOLDER/${{DOCKER_RUN}}}}"
-
-${{CMD_FINAL}} \\
-    LD_LIBRARY_PATH="{vivado_path}/lib/lnx64.o" \\
-    "{vivado_path}/bin/setEnvAndRunCmd.sh vivado" \\
-    -mode tcl "$@"
-""".format(
-        docker_run_rlocation = docker_run_rlocation,
-        cmd = cmd,
-        vivado_path = VIVADO_PATH,
-    )
-
-    ctx.actions.write(
+    
+    ctx.actions.expand_template(
+        template = ctx.file._template,
         output = executable,
-        content = script_content,
+        substitutions = {
+            "{{DOCKER_RUN_RLOCATION}}": docker_run_rlocation,
+            "{{CMD}}": cmd,
+            "{{VIVADO_PATH}}": VIVADO_PATH,
+        },
         is_executable = True,
     )
 
@@ -91,7 +49,8 @@ ${{CMD_FINAL}} \\
             executable = executable,
             runfiles = ctx.runfiles(files = [
                 docker_run,
-            ]).merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles),
+            ]).merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
+              .merge(ctx.attr._script[DefaultInfo].default_runfiles),
         ),
     ]
 
@@ -101,6 +60,10 @@ vivado_repl = rule(
     attrs = DOCKER_RUN_SCRIPT_ATTRS | {
         "_bash_runfiles": attr.label(
             default = "@bazel_tools//tools/bash/runfiles",
+        ),
+        "_template": attr.label(
+            default = "//internal:vivado_repl.sh.tpl",
+            allow_single_file = True,
         ),
     },
 )

--- a/internal/vivado_repl.md
+++ b/internal/vivado_repl.md
@@ -1,0 +1,26 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado REPL rule.
+
+<a id="vivado_repl"></a>
+
+## vivado_repl
+
+<pre>
+load("@rules_vivado//internal:vivado_repl.bzl", "vivado_repl")
+
+vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_repl-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_repl-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_repl-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+
+

--- a/internal/vivado_repl.sh.tpl
+++ b/internal/vivado_repl.sh.tpl
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "${RUNFILES_MANIFEST_FILE}" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+set -eo pipefail
+
+DOCKER_RUN=$(rlocation {{DOCKER_RUN_RLOCATION}})
+
+if [[ ! -f "${DOCKER_RUN}" ]]; then
+  echo >&2 "ERROR: cannot find docker_run at ${DOCKER_RUN}"
+  exit 1
+fi
+
+# Replace the placeholder with the actual path.
+CMD="{{CMD}}"
+CMD_FINAL="${CMD/DOCKER_RUN_PLACEHOLDER/${DOCKER_RUN}}"
+
+${CMD_FINAL} \
+    LD_LIBRARY_PATH="{{VIVADO_PATH}}/lib/lnx64.o" \
+    "{{VIVADO_PATH}}/bin/setEnvAndRunCmd.sh vivado" \
+    -mode tcl "$@"
+
+# vim: ft=bash


### PR DESCRIPTION
feat: add vivado_repl rule to start vivado in tcl repl

Adds `vivado_repl` rule in `internal/vivado_repl.bzl` and exports it in `build/vivado/rules.bzl`.
Creates a default target `//build/vivado:repl`.

This pull request has been created by an automated coding assistant,
with human supervision.

Prompt:
implement a rule that can be used to do `bazel run //rule:name` which will start vivado in repl mode without GUI using the existing docker container infrastructure, place it in @internal/**, and create a redirection in @build/vivado/rules.bzl
