### PR TITLE
docs: add stardoc for all internal bzl files and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,23 @@ It's important to note that distributing the Docker container itself is generall
 
 ## Documentation
 
-* [doc.bzl documentation](doc.md)
-* [build/vivado/rules.bzl documentation](build/vivado/rules.md)
-* [internal/defines.bzl documentation](internal/defines.md)
-* [internal/providers.bzl documentation](internal/providers.md)
+| File | Documentation | Description |
+| :--- | :--- | :--- |
+| `doc.bzl` | [doc.md](doc.md) | Documentation helper functions |
+| `build/vivado/rules.bzl` | [build/vivado/rules.md](build/vivado/rules.md) | Main Vivado rules exported by the project |
+| `internal/defines.bzl` | [internal/defines.md](internal/defines.md) | Internal defines and common functions |
+| `internal/providers.bzl` | [internal/providers.md](internal/providers.md) | Internal providers used by Vivado rules |
+| `internal/vivado_generics.bzl` | [internal/vivado_generics.md](internal/vivado_generics.md) | Macro for generating generics TCL scripts |
+| `internal/vivado_library.bzl` | [internal/vivado_library.md](internal/vivado_library.md) | Rule for defining a Vivado library |
+| `internal/vivado_place_and_route.bzl` | [internal/vivado_place_and_route.md](internal/vivado_place_and_route.md) | Rule for Vivado place and route |
+| `internal/vivado_place_and_route2.bzl` | [internal/vivado_place_and_route2.md](internal/vivado_place_and_route2.md) | Alternate rule for Vivado place and route |
+| `internal/vivado_program_device.bzl` | [internal/vivado_program_device.md](internal/vivado_program_device.md) | Rule for programming a device |
+| `internal/vivado_project.bzl` | [internal/vivado_project.md](internal/vivado_project.md) | Rule for defining a Vivado project |
+| `internal/vivado_repl.bzl` | [internal/vivado_repl.md](internal/vivado_repl.md) | Rule for running Vivado REPL |
+| `internal/vivado_simulation.bzl` | [internal/vivado_simulation.md](internal/vivado_simulation.md) | Rule for running Vivado simulation |
+| `internal/vivado_synthesis.bzl` | [internal/vivado_synthesis.md](internal/vivado_synthesis.md) | Rule for Vivado synthesis |
+| `internal/vivado_synthesis2.bzl` | [internal/vivado_synthesis2.md](internal/vivado_synthesis2.md) | Alternate rule for Vivado synthesis |
+| `internal/vivado_unisims_library.bzl` | [internal/vivado_unisims_library.md](internal/vivado_unisims_library.md) | Rule for Vivado UNISIMs library |
 
 ## Prior Art
 

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -126,10 +126,80 @@ stardoc(
 )
 
 stardoc(
+    name = "md_vivado_generics",
+    out = "gen.vivado_generics.md",
+    input = "vivado_generics.bzl",
+    deps = [":vivado_generics"],
+)
+
+stardoc(
+    name = "md_vivado_library",
+    out = "gen.vivado_library.md",
+    input = "vivado_library.bzl",
+    deps = [":vivado_library"],
+)
+
+stardoc(
+    name = "md_vivado_place_and_route",
+    out = "gen.vivado_place_and_route.md",
+    input = "vivado_place_and_route.bzl",
+    deps = [":vivado_place_and_route"],
+)
+
+stardoc(
+    name = "md_vivado_place_and_route2",
+    out = "gen.vivado_place_and_route2.md",
+    input = "vivado_place_and_route2.bzl",
+    deps = [":vivado_place_and_route2"],
+)
+
+stardoc(
+    name = "md_vivado_program_device",
+    out = "gen.vivado_program_device.md",
+    input = "vivado_program_device.bzl",
+    deps = [":vivado_program_device"],
+)
+
+stardoc(
+    name = "md_vivado_project",
+    out = "gen.vivado_project.md",
+    input = "vivado_project.bzl",
+    deps = [":vivado_project"],
+)
+
+stardoc(
     name = "md_vivado_repl",
     out = "gen.vivado_repl.md",
     input = "vivado_repl.bzl",
     deps = [":vivado_repl"],
+)
+
+stardoc(
+    name = "md_vivado_simulation",
+    out = "gen.vivado_simulation.md",
+    input = "vivado_simulation.bzl",
+    deps = [":vivado_simulation"],
+)
+
+stardoc(
+    name = "md_vivado_synthesis",
+    out = "gen.vivado_synthesis.md",
+    input = "vivado_synthesis.bzl",
+    deps = [":vivado_synthesis"],
+)
+
+stardoc(
+    name = "md_vivado_synthesis2",
+    out = "gen.vivado_synthesis2.md",
+    input = "vivado_synthesis2.bzl",
+    deps = [":vivado_synthesis2"],
+)
+
+stardoc(
+    name = "md_vivado_unisims_library",
+    out = "gen.vivado_unisims_library.md",
+    input = "vivado_unisims_library.bzl",
+    deps = [":vivado_unisims_library"],
 )
 
 write_source_files(
@@ -137,6 +207,16 @@ write_source_files(
     files = {
         "defines.md": ":md_defines",
         "providers.md": ":md_providers",
+        "vivado_generics.md": ":md_vivado_generics",
+        "vivado_library.md": ":md_vivado_library",
+        "vivado_place_and_route.md": ":md_vivado_place_and_route",
+        "vivado_place_and_route2.md": ":md_vivado_place_and_route2",
+        "vivado_program_device.md": ":md_vivado_program_device",
+        "vivado_project.md": ":md_vivado_project",
         "vivado_repl.md": ":md_vivado_repl",
+        "vivado_simulation.md": ":md_vivado_simulation",
+        "vivado_synthesis.md": ":md_vivado_synthesis",
+        "vivado_synthesis2.md": ":md_vivado_synthesis2",
+        "vivado_unisims_library.md": ":md_vivado_unisims_library",
     },
 )

--- a/internal/vivado_generics.md
+++ b/internal/vivado_generics.md
@@ -1,0 +1,30 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado generics macro.
+
+<a id="vivado_generics"></a>
+
+## vivado_generics
+
+<pre>
+load("@rules_vivado//internal:vivado_generics.bzl", "vivado_generics")
+
+vivado_generics(<a href="#vivado_generics-name">name</a>, <a href="#vivado_generics-verilog_top">verilog_top</a>, <a href="#vivado_generics-vhdl_top">vhdl_top</a>, <a href="#vivado_generics-params">params</a>, <a href="#vivado_generics-generics">generics</a>, <a href="#vivado_generics-data">data</a>, <a href="#vivado_generics-synth">synth</a>)
+</pre>
+
+Generates TCL scripts for generics/parameters.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="vivado_generics-name"></a>name |  Target name.   |  none |
+| <a id="vivado_generics-verilog_top"></a>verilog_top |  Verilog top entity.   |  `None` |
+| <a id="vivado_generics-vhdl_top"></a>vhdl_top |  VHDL top entity.   |  `None` |
+| <a id="vivado_generics-params"></a>params |  Dictionary of parameters.   |  `{}` |
+| <a id="vivado_generics-generics"></a>generics |  Dictionary of generics.   |  `{}` |
+| <a id="vivado_generics-data"></a>data |  Data targets.   |  `None` |
+| <a id="vivado_generics-synth"></a>synth |  Synthesis target.   |  `None` |
+
+

--- a/internal/vivado_library.md
+++ b/internal/vivado_library.md
@@ -1,0 +1,37 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado library rule.
+
+<a id="vivado_library"></a>
+
+## vivado_library
+
+<pre>
+load("@rules_vivado//internal:vivado_library.bzl", "vivado_library")
+
+vivado_library(<a href="#vivado_library-name">name</a>, <a href="#vivado_library-deps">deps</a>, <a href="#vivado_library-srcs">srcs</a>, <a href="#vivado_library-data">data</a>, <a href="#vivado_library-hdrs">hdrs</a>, <a href="#vivado_library-defines">defines</a>, <a href="#vivado_library-env">env</a>, <a href="#vivado_library-includes">includes</a>, <a href="#vivado_library-library_name">library_name</a>, <a href="#vivado_library-mount">mount</a>, <a href="#vivado_library-standard">standard</a>,
+               <a href="#vivado_library-use_glbl">use_glbl</a>, <a href="#vivado_library-vhdl1993">vhdl1993</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_library-deps"></a>deps |  The list of files in this library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_library-srcs"></a>srcs |  The list of files in this library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_library-data"></a>data |  The list of target that should be available for compilation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_library-hdrs"></a>hdrs |  The list of include files in this library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_library-defines"></a>defines |  The list of key-to-value mappings to apply to the compilation   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_library-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_library-includes"></a>includes |  The list of additional directories to append to the include list   | List of strings | optional |  `[]`  |
+| <a id="vivado_library-library_name"></a>library_name |  An optional library name, in the case the target name can not be used for some reason.   | String | optional |  `""`  |
+| <a id="vivado_library-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_library-standard"></a>standard |  Specify the language standard to use   | String | optional |  `"2008"`  |
+| <a id="vivado_library-use_glbl"></a>use_glbl |  Whether to use the global glbl.v.   | Boolean | optional |  `False`  |
+| <a id="vivado_library-vhdl1993"></a>vhdl1993 |  Use VHDL-1993 standard else use VHDL-2008   | Boolean | optional |  `False`  |
+
+

--- a/internal/vivado_place_and_route.md
+++ b/internal/vivado_place_and_route.md
@@ -1,0 +1,27 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado place and route rule.
+
+<a id="vivado_place_and_route"></a>
+
+## vivado_place_and_route
+
+<pre>
+load("@rules_vivado//internal:vivado_place_and_route.bzl", "vivado_place_and_route")
+
+vivado_place_and_route(<a href="#vivado_place_and_route-name">name</a>, <a href="#vivado_place_and_route-env">env</a>, <a href="#vivado_place_and_route-mount">mount</a>, <a href="#vivado_place_and_route-synthesis">synthesis</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_place_and_route-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_place_and_route-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_place_and_route-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_place_and_route-synthesis"></a>synthesis |  The vivado synthesis to place and route   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+

--- a/internal/vivado_place_and_route2.md
+++ b/internal/vivado_place_and_route2.md
@@ -1,0 +1,28 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado place and route2 rule.
+
+<a id="vivado_place_and_route2"></a>
+
+## vivado_place_and_route2
+
+<pre>
+load("@rules_vivado//internal:vivado_place_and_route2.bzl", "vivado_place_and_route2")
+
+vivado_place_and_route2(<a href="#vivado_place_and_route2-name">name</a>, <a href="#vivado_place_and_route2-env">env</a>, <a href="#vivado_place_and_route2-mount">mount</a>, <a href="#vivado_place_and_route2-synthesis">synthesis</a>, <a href="#vivado_place_and_route2-xdcs">xdcs</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_place_and_route2-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_place_and_route2-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_place_and_route2-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_place_and_route2-synthesis"></a>synthesis |  The mandatory synth2 target to use   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="vivado_place_and_route2-xdcs"></a>xdcs |  Constraint files   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+

--- a/internal/vivado_program_device.md
+++ b/internal/vivado_program_device.md
@@ -1,0 +1,28 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado program device rule.
+
+<a id="vivado_program_device"></a>
+
+## vivado_program_device
+
+<pre>
+load("@rules_vivado//internal:vivado_program_device.bzl", "vivado_program_device")
+
+vivado_program_device(<a href="#vivado_program_device-name">name</a>, <a href="#vivado_program_device-deps">deps</a>, <a href="#vivado_program_device-data">data</a>, <a href="#vivado_program_device-prog_daemon">prog_daemon</a>, <a href="#vivado_program_device-prog_daemon_args">prog_daemon_args</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_program_device-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_program_device-deps"></a>deps |  The list of deps containing bitstream code   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_program_device-data"></a>data |  The list of dependencies to expand   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_program_device-prog_daemon"></a>prog_daemon |  The binary to start before programming   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_program_device-prog_daemon_args"></a>prog_daemon_args |  The args to give to prog_daemon, subject to make var substitution   | List of strings | optional |  `[]`  |
+
+

--- a/internal/vivado_project.md
+++ b/internal/vivado_project.md
@@ -1,0 +1,34 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado project rule.
+
+<a id="vivado_project"></a>
+
+## vivado_project
+
+<pre>
+load("@rules_vivado//internal:vivado_project.bzl", "vivado_project")
+
+vivado_project(<a href="#vivado_project-name">name</a>, <a href="#vivado_project-deps">deps</a>, <a href="#vivado_project-srcs">srcs</a>, <a href="#vivado_project-hdrs">hdrs</a>, <a href="#vivado_project-defines">defines</a>, <a href="#vivado_project-env">env</a>, <a href="#vivado_project-include_dirs">include_dirs</a>, <a href="#vivado_project-mount">mount</a>, <a href="#vivado_project-part">part</a>, <a href="#vivado_project-top_level">top_level</a>, <a href="#vivado_project-xdcs">xdcs</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_project-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_project-deps"></a>deps |  The list of library dependencies   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_project-srcs"></a>srcs |  A list of source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_project-hdrs"></a>hdrs |  A list of header files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_project-defines"></a>defines |  A list of defines.   | List of strings | optional |  `[]`  |
+| <a id="vivado_project-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_project-include_dirs"></a>include_dirs |  A list of include directories.   | List of strings | optional |  `[]`  |
+| <a id="vivado_project-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_project-part"></a>part |  The part that is targeted by this project   | String | required |  |
+| <a id="vivado_project-top_level"></a>top_level |  Top level entity name   | String | required |  |
+| <a id="vivado_project-xdcs"></a>xdcs |  A list of constraints files to use.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+

--- a/internal/vivado_simulation.md
+++ b/internal/vivado_simulation.md
@@ -1,0 +1,39 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado simulation rule.
+
+<a id="vivado_simulation"></a>
+
+## vivado_simulation
+
+<pre>
+load("@rules_vivado//internal:vivado_simulation.bzl", "vivado_simulation")
+
+vivado_simulation(<a href="#vivado_simulation-name">name</a>, <a href="#vivado_simulation-data">data</a>, <a href="#vivado_simulation-args">args</a>, <a href="#vivado_simulation-config">config</a>, <a href="#vivado_simulation-custom_tcl_script">custom_tcl_script</a>, <a href="#vivado_simulation-defines">defines</a>, <a href="#vivado_simulation-env">env</a>, <a href="#vivado_simulation-extra_modules">extra_modules</a>,
+                  <a href="#vivado_simulation-generic_tops">generic_tops</a>, <a href="#vivado_simulation-library">library</a>, <a href="#vivado_simulation-mount">mount</a>, <a href="#vivado_simulation-template">template</a>, <a href="#vivado_simulation-top">top</a>, <a href="#vivado_simulation-xelab_args">xelab_args</a>, <a href="#vivado_simulation-xelab_relaxed">xelab_relaxed</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_simulation-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_simulation-data"></a>data |  A list of data targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_simulation-args"></a>args |  Custom args to xsim   | List of strings | optional |  `[]`  |
+| <a id="vivado_simulation-config"></a>config |  If specified, the said named configuration will be selected (VHDL)   | String | optional |  `""`  |
+| <a id="vivado_simulation-custom_tcl_script"></a>custom_tcl_script |  Custom TCL script to run simulation with   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_simulation-defines"></a>defines |  The list of key-to-value mappings to apply to the compilation   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_simulation-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_simulation-extra_modules"></a>extra_modules |  Names of additional modules to co-simulate   | List of strings | optional |  `[]`  |
+| <a id="vivado_simulation-generic_tops"></a>generic_tops |  The list of key-to-value mappings to apply to the compilation   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_simulation-library"></a>library |  The library to run the simulation from   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_simulation-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_simulation-template"></a>template |  The TCL template to run.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_vivado//build/vivado:xsim.tcl.template"`  |
+| <a id="vivado_simulation-top"></a>top |  Name of the top level entity to simulate   | String | optional |  `""`  |
+| <a id="vivado_simulation-xelab_args"></a>xelab_args |  Custom args to elaboration step   | List of strings | optional |  `[]`  |
+| <a id="vivado_simulation-xelab_relaxed"></a>xelab_relaxed |  Relax HDL checks, sometimes needed for Verilog modules   | Boolean | optional |  `False`  |
+
+

--- a/internal/vivado_synthesis.md
+++ b/internal/vivado_synthesis.md
@@ -1,0 +1,27 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado synthesis rule.
+
+<a id="vivado_synthesis"></a>
+
+## vivado_synthesis
+
+<pre>
+load("@rules_vivado//internal:vivado_synthesis.bzl", "vivado_synthesis")
+
+vivado_synthesis(<a href="#vivado_synthesis-name">name</a>, <a href="#vivado_synthesis-env">env</a>, <a href="#vivado_synthesis-mount">mount</a>, <a href="#vivado_synthesis-project">project</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_synthesis-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_synthesis-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis-project"></a>project |  The Vivado project to work on   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+

--- a/internal/vivado_synthesis2.md
+++ b/internal/vivado_synthesis2.md
@@ -1,0 +1,37 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado synthesis2 rule.
+
+<a id="vivado_synthesis2"></a>
+
+## vivado_synthesis2
+
+<pre>
+load("@rules_vivado//internal:vivado_synthesis2.bzl", "vivado_synthesis2")
+
+vivado_synthesis2(<a href="#vivado_synthesis2-name">name</a>, <a href="#vivado_synthesis2-deps">deps</a>, <a href="#vivado_synthesis2-srcs">srcs</a>, <a href="#vivado_synthesis2-data">data</a>, <a href="#vivado_synthesis2-hdrs">hdrs</a>, <a href="#vivado_synthesis2-defines">defines</a>, <a href="#vivado_synthesis2-env">env</a>, <a href="#vivado_synthesis2-generics">generics</a>, <a href="#vivado_synthesis2-include_dirs">include_dirs</a>, <a href="#vivado_synthesis2-mount">mount</a>, <a href="#vivado_synthesis2-part">part</a>,
+                  <a href="#vivado_synthesis2-top">top</a>, <a href="#vivado_synthesis2-xdcs">xdcs</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_synthesis2-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_synthesis2-deps"></a>deps |  The sources for the libraries   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_synthesis2-srcs"></a>srcs |  The sources for the `work` library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_synthesis2-data"></a>data |  Other data   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_synthesis2-hdrs"></a>hdrs |  The headers for the `work` library if verilog   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_synthesis2-defines"></a>defines |  A dictionary of defines.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-generics"></a>generics |  A dictionary of generics.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-include_dirs"></a>include_dirs |  A list of include directories.   | List of strings | optional |  `[]`  |
+| <a id="vivado_synthesis2-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_synthesis2-part"></a>part |  The part that is targeted by this project   | String | required |  |
+| <a id="vivado_synthesis2-top"></a>top |  Mandatory name of the top level entity   | String | required |  |
+| <a id="vivado_synthesis2-xdcs"></a>xdcs |  Constraint files   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+

--- a/internal/vivado_unisims_library.md
+++ b/internal/vivado_unisims_library.md
@@ -1,0 +1,40 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado unisims library rule.
+
+<a id="vivado_unisims_library"></a>
+
+## vivado_unisims_library
+
+<pre>
+load("@rules_vivado//internal:vivado_unisims_library.bzl", "vivado_unisims_library")
+
+vivado_unisims_library(<a href="#vivado_unisims_library-name">name</a>, <a href="#vivado_unisims_library-env">env</a>, <a href="#vivado_unisims_library-export_libraries">export_libraries</a>, <a href="#vivado_unisims_library-family">family</a>, <a href="#vivado_unisims_library-force">force</a>, <a href="#vivado_unisims_library-language">language</a>, <a href="#vivado_unisims_library-libraries">libraries</a>, <a href="#vivado_unisims_library-mount">mount</a>,
+                       <a href="#vivado_unisims_library-no_ip_compile">no_ip_compile</a>, <a href="#vivado_unisims_library-no_systemc_compile">no_systemc_compile</a>, <a href="#vivado_unisims_library-quiet">quiet</a>, <a href="#vivado_unisims_library-simulator">simulator</a>, <a href="#vivado_unisims_library-skip_libraries">skip_libraries</a>, <a href="#vivado_unisims_library-template">template</a>,
+                       <a href="#vivado_unisims_library-verbose">verbose</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_unisims_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_unisims_library-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_unisims_library-export_libraries"></a>export_libraries |  The libraries to make available to users.   | List of strings | optional |  `["unisim", "unimacro", "unifast"]`  |
+| <a id="vivado_unisims_library-family"></a>family |  The device family to compile the library for.   | String | optional |  `"artix7"`  |
+| <a id="vivado_unisims_library-force"></a>force |  Whether to force compilation.   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-language"></a>language |  The language to compile for: vhdl\|verilog\|all   | String | optional |  `"vhdl"`  |
+| <a id="vivado_unisims_library-libraries"></a>libraries |  The libraries to compile: unisim\|simprim\|...\|all   | List of strings | optional |  `["unisim"]`  |
+| <a id="vivado_unisims_library-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_unisims_library-no_ip_compile"></a>no_ip_compile |  Whether to skip IP compile.   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-no_systemc_compile"></a>no_systemc_compile |  Whether to skip SystemC compile.   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-quiet"></a>quiet |  Whether to be quiet.   | Boolean | optional |  `False`  |
+| <a id="vivado_unisims_library-simulator"></a>simulator |  Name of the top level entity to simulate   | String | optional |  `"xsim"`  |
+| <a id="vivado_unisims_library-skip_libraries"></a>skip_libraries |  The list of libraries to skip.   | List of strings | optional |  `[]`  |
+| <a id="vivado_unisims_library-template"></a>template |  The template for the compile_simlib script.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_vivado//build/vivado:compile_simlib_tcl_template"`  |
+| <a id="vivado_unisims_library-verbose"></a>verbose |  Whether to be verbose.   | Boolean | optional |  `False`  |
+
+


### PR DESCRIPTION
docs: add stardoc for all internal bzl files and update README

Added `stardoc` targets to `internal/BUILD.bazel` for all remaining
`.bzl` files.
Generated the corresponding `.md` documentation files.
Updated `README.md` to display all documentation links in a table.

This pull request has been created by an automated coding assistant,
with human supervision.

Prompt:
add `stardoc` targets and `write_source_files` for *all* bzl libraries. document all public API items in the bzl libraries, modify README.md to provide tabular links to all the documentation .md files
