### PR TITLE
feat: add vivado_gui rule to start vivado in gui mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,33 @@ It's important to note that distributing the Docker container itself is generall
 | `internal/vivado_program_device.bzl` | [internal/vivado_program_device.md](internal/vivado_program_device.md) | Rule for programming a device |
 | `internal/vivado_project.bzl` | [internal/vivado_project.md](internal/vivado_project.md) | Rule for defining a Vivado project |
 | `internal/vivado_repl.bzl` | [internal/vivado_repl.md](internal/vivado_repl.md) | Rule for running Vivado REPL |
+| `internal/vivado_gui.bzl` | [internal/vivado_gui.md](internal/vivado_gui.md) | Rule for running Vivado GUI |
 | `internal/vivado_simulation.bzl` | [internal/vivado_simulation.md](internal/vivado_simulation.md) | Rule for running Vivado simulation |
 | `internal/vivado_synthesis.bzl` | [internal/vivado_synthesis.md](internal/vivado_synthesis.md) | Rule for Vivado synthesis |
 | `internal/vivado_synthesis2.bzl` | [internal/vivado_synthesis2.md](internal/vivado_synthesis2.md) | Alternate rule for Vivado synthesis |
 | `internal/vivado_unisims_library.bzl` | [internal/vivado_unisims_library.md](internal/vivado_unisims_library.md) | Rule for Vivado UNISIMs library |
+
+## Usage
+
+### Running Vivado REPL
+
+You can start a Vivado TCL REPL session using Bazel:
+
+```bash
+bazel run //build/vivado:repl
+```
+
+This will start Vivado in TCL mode within the container, mounting your current workspace.
+
+### Running Vivado GUI
+
+You can start the Vivado GUI using Bazel:
+
+```bash
+bazel run //build/vivado:gui
+```
+
+This requires an X11 server running on your host and will forward the X11 socket to the container.
 
 ## Prior Art
 

--- a/build/vivado/BUILD.bazel
+++ b/build/vivado/BUILD.bazel
@@ -53,13 +53,18 @@ bzl_library(
         "//internal:vivado_unisims_library",
         "//internal:vivado_generics",
         "//internal:vivado_repl",
+        "//internal:vivado_gui",
     ],
 )
 
-load(":rules.bzl", "vivado_repl")
+load(":rules.bzl", "vivado_gui", "vivado_repl")
 
 vivado_repl(
     name = "repl",
+)
+
+vivado_gui(
+    name = "gui",
 )
 
 stardoc(

--- a/build/vivado/rules.bzl
+++ b/build/vivado/rules.bzl
@@ -11,6 +11,7 @@ load("//internal:vivado_simulation.bzl", _vivado_simulation = "vivado_simulation
 load("//internal:vivado_unisims_library.bzl", _vivado_unisims_library = "vivado_unisims_library")
 load("//internal:vivado_generics.bzl", _vivado_generics = "vivado_generics")
 load("//internal:vivado_repl.bzl", _vivado_repl = "vivado_repl")
+load("//internal:vivado_gui.bzl", _vivado_gui = "vivado_gui")
 
 vivado_project = _vivado_project
 vivado_synthesis = _vivado_synthesis
@@ -23,3 +24,4 @@ vivado_simulation = _vivado_simulation
 vivado_unisims_library = _vivado_unisims_library
 vivado_generics = _vivado_generics
 vivado_repl = _vivado_repl
+vivado_gui = _vivado_gui

--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -2,6 +2,28 @@
 
 Vivado rules for Bazel.
 
+<a id="vivado_gui"></a>
+
+## vivado_gui
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_gui")
+
+vivado_gui(<a href="#vivado_gui-name">name</a>, <a href="#vivado_gui-env">env</a>, <a href="#vivado_gui-mount">mount</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_gui-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_gui-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_gui-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+
+
 <a id="vivado_library"></a>
 
 ## vivado_library

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -4,7 +4,10 @@ load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["vivado_repl.sh.tpl"])
+exports_files([
+    "vivado_repl.sh.tpl",
+    "vivado_gui.sh.tpl",
+])
 
 bzl_library(
     name = "defines",
@@ -111,6 +114,14 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "vivado_gui",
+    srcs = ["vivado_gui.bzl"],
+    deps = [
+        ":defines",
+    ],
+)
+
 stardoc(
     name = "md_defines",
     out = "gen.defines.md",
@@ -175,6 +186,13 @@ stardoc(
 )
 
 stardoc(
+    name = "md_vivado_gui",
+    out = "gen.vivado_gui.md",
+    input = "vivado_gui.bzl",
+    deps = [":vivado_gui"],
+)
+
+stardoc(
     name = "md_vivado_simulation",
     out = "gen.vivado_simulation.md",
     input = "vivado_simulation.bzl",
@@ -214,6 +232,7 @@ write_source_files(
         "vivado_program_device.md": ":md_vivado_program_device",
         "vivado_project.md": ":md_vivado_project",
         "vivado_repl.md": ":md_vivado_repl",
+        "vivado_gui.md": ":md_vivado_gui",
         "vivado_simulation.md": ":md_vivado_simulation",
         "vivado_synthesis.md": ":md_vivado_synthesis",
         "vivado_synthesis2.md": ":md_vivado_synthesis2",

--- a/internal/vivado_gui.bzl
+++ b/internal/vivado_gui.bzl
@@ -16,20 +16,20 @@ def _vivado_gui_impl(ctx):
       A DefaultInfo provider.
     """
     executable = ctx.actions.declare_file(ctx.label.name + ".sh")
-    
+
     docker_run = ctx.executable._script
-    
+
     # We use rlocation to find the docker_run script at runtime.
     docker_run_rlocation = "rules_bid/build/docker_run"
-    
+
     # Generate the command using the helper.
     cmd = _script_cmd(
         script_path = "DOCKER_RUN_PLACEHOLDER",
         dir_reference = ".",
         cache_dir = ".vivado_gui_cache",
-        freeargs = ["-it", "--net=host", "-e", "HOME=/work"],
+        freeargs = ["-it", "--net=host"],
     )
-    
+
     ctx.actions.expand_template(
         template = ctx.file._template,
         output = executable,

--- a/internal/vivado_gui.bzl
+++ b/internal/vivado_gui.bzl
@@ -1,0 +1,66 @@
+"""Vivado GUI rule."""
+
+load("//internal:defines.bzl",
+    "VIVADO_PATH",
+    "DOCKER_RUN_SCRIPT_ATTRS",
+    _script_cmd = "script_cmd",
+)
+
+def _vivado_gui_impl(ctx):
+    """Implementation for the vivado_gui rule.
+
+    Args:
+      ctx: The rule context.
+
+    Returns:
+      A DefaultInfo provider.
+    """
+    executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+    
+    docker_run = ctx.executable._script
+    
+    # We use rlocation to find the docker_run script at runtime.
+    docker_run_rlocation = "rules_bid/build/docker_run"
+    
+    # Generate the command using the helper.
+    cmd = _script_cmd(
+        script_path = "DOCKER_RUN_PLACEHOLDER",
+        dir_reference = ".",
+        cache_dir = ".vivado_gui_cache",
+        freeargs = ["-it", "--net=host", "-e", "HOME=/work"],
+    )
+    
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = executable,
+        substitutions = {
+            "{{DOCKER_RUN_RLOCATION}}": docker_run_rlocation,
+            "{{CMD}}": cmd,
+            "{{VIVADO_PATH}}": VIVADO_PATH,
+        },
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = ctx.runfiles(files = [
+                docker_run,
+            ]).merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
+              .merge(ctx.attr._script[DefaultInfo].default_runfiles),
+        ),
+    ]
+
+vivado_gui = rule(
+    implementation = _vivado_gui_impl,
+    executable = True,
+    attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+        "_bash_runfiles": attr.label(
+            default = "@bazel_tools//tools/bash/runfiles",
+        ),
+        "_template": attr.label(
+            default = "//internal:vivado_gui.sh.tpl",
+            allow_single_file = True,
+        ),
+    },
+)

--- a/internal/vivado_gui.md
+++ b/internal/vivado_gui.md
@@ -1,0 +1,26 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Vivado GUI rule.
+
+<a id="vivado_gui"></a>
+
+## vivado_gui
+
+<pre>
+load("@rules_vivado//internal:vivado_gui.bzl", "vivado_gui")
+
+vivado_gui(<a href="#vivado_gui-name">name</a>, <a href="#vivado_gui-env">env</a>, <a href="#vivado_gui-mount">mount</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_gui-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_gui-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_gui-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+
+

--- a/internal/vivado_gui.sh.tpl
+++ b/internal/vivado_gui.sh.tpl
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "${RUNFILES_MANIFEST_FILE}" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+set -eo pipefail
+
+DOCKER_RUN=$(rlocation {{DOCKER_RUN_RLOCATION}})
+
+if [[ ! -f "${DOCKER_RUN}" ]]; then
+  echo >&2 "ERROR: cannot find docker_run at ${DOCKER_RUN}"
+  exit 1
+fi
+
+# Replace the placeholder with the actual path.
+CMD="{{CMD}}"
+CMD_FINAL="${CMD/DOCKER_RUN_PLACEHOLDER/${DOCKER_RUN}}"
+
+# Ensure DISPLAY is set.
+if [[ -z "${DISPLAY}" ]]; then
+  echo >&2 "WARNING: DISPLAY is not set. GUI might not start correctly."
+fi
+
+${CMD_FINAL} \
+    -e DISPLAY="${DISPLAY}" \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    LD_LIBRARY_PATH="{{VIVADO_PATH}}/lib/lnx64.o" \
+    "{{VIVADO_PATH}}/bin/setEnvAndRunCmd.sh vivado" \
+    -mode gui "$@"
+
+# vim: ft=bash

--- a/internal/vivado_gui.sh.tpl
+++ b/internal/vivado_gui.sh.tpl
@@ -40,9 +40,15 @@ if [[ -z "${DISPLAY}" ]]; then
   echo >&2 "WARNING: DISPLAY is not set. GUI might not start correctly."
 fi
 
+# Create a local home directory to give Vivado write access for its configs.
+VIVADO_HOME_DIR="${PWD}/.vivado_home"
+mkdir -p "${VIVADO_HOME_DIR}"
+chmod a+w "${VIVADO_HOME_DIR}"
+
 ${CMD_FINAL} \
-    -e DISPLAY="${DISPLAY}" \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    --envs="DISPLAY=${DISPLAY},HOME=/home/vivado" \
+    --mounts="/tmp/.X11-unix:/tmp/.X11-unix,${VIVADO_HOME_DIR}:/home/vivado:rw" \
+    -- \
     LD_LIBRARY_PATH="{{VIVADO_PATH}}/lib/lnx64.o" \
     "{{VIVADO_PATH}}/bin/setEnvAndRunCmd.sh vivado" \
     -mode gui "$@"


### PR DESCRIPTION
feat: add vivado_gui rule to start vivado in gui mode

Adds `vivado_repl` rule in `internal/vivado_gui.bzl` and exports it in `build/vivado/rules.bzl`.
Forward X11 socket and DISPLAY env variable to the container for GUI support.
Creates a default target `//build/vivado:gui`.
Updates README with usage instructions for REPL and GUI.

This pull request has been created by an automated coding assistant,
with human supervision.

Prompt:
new pr in a new branch; feature: add another runnable bazel rules which runs vivado with gui, don't forget to forward the X11 socket into the container, to make this possible
