### PR TITLE
feat: allow custom startup scripts for vivado REPL and GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ bazel run //build/vivado:repl
 
 This will start Vivado in TCL mode within the container, mounting your current workspace.
 
+You can also pass a custom TCL script to be executed upon startup using the `script` attribute:
+
+```python
+vivado_repl(
+    name = "repl_with_script",
+    script = "my_script.tcl",
+)
+```
+
 ### Running Vivado GUI
 
 You can start the Vivado GUI using Bazel:
@@ -57,6 +66,15 @@ bazel run //build/vivado:gui
 ```
 
 This requires an X11 server running on your host and will forward the X11 socket to the container.
+
+Similarly to the REPL, you can pass a custom TCL script to be executed upon startup:
+
+```python
+vivado_gui(
+    name = "gui_with_script",
+    script = "my_script.tcl",
+)
+```
 
 ## Prior Art
 

--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -9,7 +9,7 @@ Vivado rules for Bazel.
 <pre>
 load("@rules_vivado//build/vivado:rules.bzl", "vivado_gui")
 
-vivado_gui(<a href="#vivado_gui-name">name</a>, <a href="#vivado_gui-env">env</a>, <a href="#vivado_gui-mount">mount</a>)
+vivado_gui(<a href="#vivado_gui-name">name</a>, <a href="#vivado_gui-env">env</a>, <a href="#vivado_gui-mount">mount</a>, <a href="#vivado_gui-script">script</a>)
 </pre>
 
 
@@ -22,6 +22,7 @@ vivado_gui(<a href="#vivado_gui-name">name</a>, <a href="#vivado_gui-env">env</a
 | <a id="vivado_gui-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="vivado_gui-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_gui-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_gui-script"></a>script |  Optional TCL script to run on startup.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 
 <a id="vivado_library"></a>
@@ -165,7 +166,7 @@ vivado_project(<a href="#vivado_project-name">name</a>, <a href="#vivado_project
 <pre>
 load("@rules_vivado//build/vivado:rules.bzl", "vivado_repl")
 
-vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>)
+vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>, <a href="#vivado_repl-script">script</a>)
 </pre>
 
 
@@ -178,6 +179,7 @@ vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env
 | <a id="vivado_repl-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="vivado_repl-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_repl-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_repl-script"></a>script |  Optional TCL script to run on startup.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 
 <a id="vivado_simulation"></a>

--- a/internal/vivado_gui.bzl
+++ b/internal/vivado_gui.bzl
@@ -22,6 +22,15 @@ def _vivado_gui_impl(ctx):
     # We use rlocation to find the docker_run script at runtime.
     docker_run_rlocation = "rules_bid/build/docker_run"
 
+    script_rlocation = ""
+    runfiles_list = [docker_run]
+    if ctx.file.script:
+        runfiles_list.append(ctx.file.script)
+        if ctx.file.script.short_path.startswith("../"):
+            script_rlocation = ctx.file.script.short_path[3:]
+        else:
+            script_rlocation = ctx.workspace_name + "/" + ctx.file.script.short_path
+
     # Generate the command using the helper.
     cmd = _script_cmd(
         script_path = "DOCKER_RUN_PLACEHOLDER",
@@ -35,6 +44,7 @@ def _vivado_gui_impl(ctx):
         output = executable,
         substitutions = {
             "{{DOCKER_RUN_RLOCATION}}": docker_run_rlocation,
+            "{{SCRIPT_RLOCATION}}": script_rlocation,
             "{{CMD}}": cmd,
             "{{VIVADO_PATH}}": VIVADO_PATH,
         },
@@ -44,9 +54,7 @@ def _vivado_gui_impl(ctx):
     return [
         DefaultInfo(
             executable = executable,
-            runfiles = ctx.runfiles(files = [
-                docker_run,
-            ]).merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
+            runfiles = ctx.runfiles(files = runfiles_list).merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
               .merge(ctx.attr._script[DefaultInfo].default_runfiles),
         ),
     ]
@@ -55,6 +63,10 @@ vivado_gui = rule(
     implementation = _vivado_gui_impl,
     executable = True,
     attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+        "script": attr.label(
+            allow_single_file = [".tcl"],
+            doc = "Optional TCL script to run on startup.",
+        ),
         "_bash_runfiles": attr.label(
             default = "@bazel_tools//tools/bash/runfiles",
         ),

--- a/internal/vivado_gui.md
+++ b/internal/vivado_gui.md
@@ -9,7 +9,7 @@ Vivado GUI rule.
 <pre>
 load("@rules_vivado//internal:vivado_gui.bzl", "vivado_gui")
 
-vivado_gui(<a href="#vivado_gui-name">name</a>, <a href="#vivado_gui-env">env</a>, <a href="#vivado_gui-mount">mount</a>)
+vivado_gui(<a href="#vivado_gui-name">name</a>, <a href="#vivado_gui-env">env</a>, <a href="#vivado_gui-mount">mount</a>, <a href="#vivado_gui-script">script</a>)
 </pre>
 
 
@@ -22,5 +22,6 @@ vivado_gui(<a href="#vivado_gui-name">name</a>, <a href="#vivado_gui-env">env</a
 | <a id="vivado_gui-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="vivado_gui-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_gui-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_gui-script"></a>script |  Optional TCL script to run on startup.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 

--- a/internal/vivado_gui.sh.tpl
+++ b/internal/vivado_gui.sh.tpl
@@ -45,12 +45,22 @@ VIVADO_HOME_DIR="${PWD}/.vivado_home"
 mkdir -p "${VIVADO_HOME_DIR}"
 chmod a+w "${VIVADO_HOME_DIR}"
 
+EXTRA_ARGS=()
+if [[ -n "{{SCRIPT_RLOCATION}}" ]]; then
+    SCRIPT_PATH=$(rlocation "{{SCRIPT_RLOCATION}}")
+    if [[ ! -f "${SCRIPT_PATH}" ]]; then
+        echo >&2 "ERROR: Cannot find script at rlocation {{SCRIPT_RLOCATION}}"
+        exit 1
+    fi
+    EXTRA_ARGS+=("-source" "${SCRIPT_PATH}")
+fi
+
 ${CMD_FINAL} \
     --envs="DISPLAY=${DISPLAY},HOME=/home/vivado" \
     --mounts="/tmp/.X11-unix:/tmp/.X11-unix,${VIVADO_HOME_DIR}:/home/vivado:rw" \
     -- \
     LD_LIBRARY_PATH="{{VIVADO_PATH}}/lib/lnx64.o" \
     "{{VIVADO_PATH}}/bin/setEnvAndRunCmd.sh vivado" \
-    -mode gui "$@"
+    -mode gui "${EXTRA_ARGS[@]}" "$@"
 
 # vim: ft=bash

--- a/internal/vivado_repl.bzl
+++ b/internal/vivado_repl.bzl
@@ -24,6 +24,15 @@ def _vivado_repl_impl(ctx):
     # rules_bid is the repo name.
     docker_run_rlocation = "rules_bid/build/docker_run"
     
+    script_rlocation = ""
+    runfiles_list = [docker_run]
+    if ctx.file.script:
+        runfiles_list.append(ctx.file.script)
+        if ctx.file.script.short_path.startswith("../"):
+            script_rlocation = ctx.file.script.short_path[3:]
+        else:
+            script_rlocation = ctx.workspace_name + "/" + ctx.file.script.short_path
+
     # Generate the command using the helper.
     # We'll use a placeholder for the script path and replace it in the bash script.
     cmd = _script_cmd(
@@ -38,6 +47,7 @@ def _vivado_repl_impl(ctx):
         output = executable,
         substitutions = {
             "{{DOCKER_RUN_RLOCATION}}": docker_run_rlocation,
+            "{{SCRIPT_RLOCATION}}": script_rlocation,
             "{{CMD}}": cmd,
             "{{VIVADO_PATH}}": VIVADO_PATH,
         },
@@ -47,9 +57,7 @@ def _vivado_repl_impl(ctx):
     return [
         DefaultInfo(
             executable = executable,
-            runfiles = ctx.runfiles(files = [
-                docker_run,
-            ]).merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
+            runfiles = ctx.runfiles(files = runfiles_list).merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
               .merge(ctx.attr._script[DefaultInfo].default_runfiles),
         ),
     ]
@@ -58,6 +66,10 @@ vivado_repl = rule(
     implementation = _vivado_repl_impl,
     executable = True,
     attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+        "script": attr.label(
+            allow_single_file = [".tcl"],
+            doc = "Optional TCL script to run on startup.",
+        ),
         "_bash_runfiles": attr.label(
             default = "@bazel_tools//tools/bash/runfiles",
         ),

--- a/internal/vivado_repl.md
+++ b/internal/vivado_repl.md
@@ -9,7 +9,7 @@ Vivado REPL rule.
 <pre>
 load("@rules_vivado//internal:vivado_repl.bzl", "vivado_repl")
 
-vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>)
+vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>, <a href="#vivado_repl-script">script</a>)
 </pre>
 
 
@@ -22,5 +22,6 @@ vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env
 | <a id="vivado_repl-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="vivado_repl-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_repl-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_repl-script"></a>script |  Optional TCL script to run on startup.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 

--- a/internal/vivado_repl.sh.tpl
+++ b/internal/vivado_repl.sh.tpl
@@ -35,9 +35,19 @@ fi
 CMD="{{CMD}}"
 CMD_FINAL="${CMD/DOCKER_RUN_PLACEHOLDER/${DOCKER_RUN}}"
 
+EXTRA_ARGS=()
+if [[ -n "{{SCRIPT_RLOCATION}}" ]]; then
+    SCRIPT_PATH=$(rlocation "{{SCRIPT_RLOCATION}}")
+    if [[ ! -f "${SCRIPT_PATH}" ]]; then
+        echo >&2 "ERROR: Cannot find script at rlocation {{SCRIPT_RLOCATION}}"
+        exit 1
+    fi
+    EXTRA_ARGS+=("-source" "${SCRIPT_PATH}")
+fi
+
 ${CMD_FINAL} \
     LD_LIBRARY_PATH="{{VIVADO_PATH}}/lib/lnx64.o" \
     "{{VIVADO_PATH}}/bin/setEnvAndRunCmd.sh vivado" \
-    -mode tcl "$@"
+    -mode tcl "${EXTRA_ARGS[@]}" "$@"
 
 # vim: ft=bash


### PR DESCRIPTION
feat: allow custom startup scripts for vivado REPL and GUI

Added a `script` attribute to `vivado_repl` and `vivado_gui` rules.
This allows providing a custom TCL script to be executed when Vivado starts up
using the `-source` flag.
Generated documentation and updated README with usage instructions.

This pull request has been created by an automated coding assistant,
with human supervision.

Prompt:
new pr; modify the repl and gui rules to accept a label argument to suppy a custom TCL script to vivado once it starts
User steering update:
<user_input>
document, run tests to confirm that .md files are up to date, update README, then send pr
</user_input>
