### PR TITLE
Demonstrate Vivado IP usage in integration repo

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -90,7 +90,7 @@ workspace.
 ## Common Commands
 
 *   **Build Everything**: `bazel build //...`
-*   **Test Everything**: `bazel test //... && cd integration && bazel test //...`
+*   **Test Everything**: `bazel test //... && cd integration && bazel build //... && bazel test //...`
 *   **List Targets**: Use `bazel query` to list targets defined below a certain
     path.
     *   Example: `bazel query //foo/bar/...` lists all targets under

--- a/integration/ip/custom_ip/BUILD.bazel
+++ b/integration/ip/custom_ip/BUILD.bazel
@@ -17,6 +17,6 @@ vivado_ip(
 # This target shows how to use the generated IP as a dependency
 vivado_library(
     name = "lib_using_ip",
-    srcs = [],
+    srcs = ["top.sv"],
     deps = [":clk_wiz_0"],
 )

--- a/integration/ip/custom_ip/top.sv
+++ b/integration/ip/custom_ip/top.sv
@@ -1,0 +1,16 @@
+module top(
+    input logic clk_in,
+    input logic rst,
+    output logic clk_out,
+    output logic locked
+);
+
+    // Instantiate the generated clock wizard IP
+    clk_wiz_0 clk_wiz_inst (
+        .clk_in1(clk_in),
+        .reset(rst),
+        .clk_out1(clk_out),
+        .locked(locked)
+    );
+
+endmodule


### PR DESCRIPTION
feat(integration): demonstrate Vivado IP usage

This pull request adds a SystemVerilog wrapper to instantiate a generated IP 
core in the integration repository, demonstrating how to use the 
VivadoLibraryProvider for simulation.

Prompt:
try building `bazel build //ip/custom_ip/...` in the integration repo, see it fail, and fix it
so when I run vivado_ip rule, how do I use the generated IP blocks?
implement this in integration repo, then run a build to show me that it works
what were you trying to do?
yes, try it
create PR for this
edit the commit message and the PR messages to match @GEMINI.md
new pr; send the current changes
reread @GEMINI.md

This pull request has been created by an automated coding assistant,
with human supervision.