### PR TITLE
🧹 Remove commented out list comprehension in vivado synthesis

### DIFF
--- a/internal/vivado_synthesis2.bzl
+++ b/internal/vivado_synthesis2.bzl
@@ -106,8 +106,6 @@ def _vivado_synthesis2_impl(ctx):
         expanded = ctx.expand_location(v, targets = ctx.attr.data)
         processed_generics += ["{}={}".format(k, expanded)]
 
-    # data_files = [ file for file in target.files.to_list() for target in ctx.attr.data ]
-    # ???
     data_files = []
     for target in ctx.attr.data:
         for file in target.files.to_list():


### PR DESCRIPTION
🎯 **What:** Removed commented-out list comprehension and placeholder comments in `internal/vivado_synthesis2.bzl`.
💡 **Why:** The code was already refactored into a loop, making the commented-out version redundant and cluttering.
✅ **Verification:** Manual inspection and verification of surrounding code logic. Ran available Go tests.
✨ **Result:** Improved maintainability and readability of the Vivado synthesis rule.

---
*PR created automatically by Jules for task [15999240129786113520](https://jules.google.com/task/15999240129786113520) started by @filmil*