### PR TITLE
feat: adds slots to specify synthesis options in the TCL script

### DIFF
--- a/build/vivado/bin/xprgen/main.go
+++ b/build/vivado/bin/xprgen/main.go
@@ -76,6 +76,11 @@ type XPRBinding struct {
 	RouteDesignOptions string
 	// PostRouteDesign are appended after `route_design` line.
 	PostRouteDesign []string
+
+	// SynthDesignOptions are appended to `synth_design` line.
+	SynthDesignOptions string
+	// PostSynthDesign are appended after `synth_design` line.
+	PostSynthDesign []string
 }
 
 var _ flag.Value = (*RepeatedString)(nil)
@@ -203,6 +208,10 @@ func run(args []string, stdout, stderr io.Writer) error {
 	var postRouteDesign RepeatedString
 	fs.Var(&postRouteDesign, "post-route-design", "Commands to run after route_design")
 
+	fs.StringVar(&xpr.SynthDesignOptions, "synth-design-options", "", "Options to append to synth_design")
+	var postSynthDesign RepeatedString
+	fs.Var(&postSynthDesign, "post-synth-design", "Commands to run after synth_design")
+
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -274,6 +283,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 	xpr.VHDLGenerics = generics.values
 	xpr.PostRouteDesign = postRouteDesign.values
 	xpr.PostPlaceDesign = postPlaceDesign.values
+	xpr.PostSynthDesign = postSynthDesign.values
 
 	if xpr.OutXpr != "" {
 		if err := WriteFile(xpr.OutXpr, xprTpl, &xpr); err != nil {

--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -279,7 +279,7 @@ vivado_synthesis(<a href="#vivado_synthesis-name">name</a>, <a href="#vivado_syn
 load("@rules_vivado//build/vivado:rules.bzl", "vivado_synthesis2")
 
 vivado_synthesis2(<a href="#vivado_synthesis2-name">name</a>, <a href="#vivado_synthesis2-deps">deps</a>, <a href="#vivado_synthesis2-srcs">srcs</a>, <a href="#vivado_synthesis2-data">data</a>, <a href="#vivado_synthesis2-hdrs">hdrs</a>, <a href="#vivado_synthesis2-defines">defines</a>, <a href="#vivado_synthesis2-env">env</a>, <a href="#vivado_synthesis2-generics">generics</a>, <a href="#vivado_synthesis2-include_dirs">include_dirs</a>, <a href="#vivado_synthesis2-mount">mount</a>, <a href="#vivado_synthesis2-part">part</a>,
-                  <a href="#vivado_synthesis2-top">top</a>, <a href="#vivado_synthesis2-xdcs">xdcs</a>)
+                  <a href="#vivado_synthesis2-post_synth_design">post_synth_design</a>, <a href="#vivado_synthesis2-synth_design_options">synth_design_options</a>, <a href="#vivado_synthesis2-top">top</a>, <a href="#vivado_synthesis2-xdcs">xdcs</a>)
 </pre>
 
 
@@ -300,6 +300,8 @@ vivado_synthesis2(<a href="#vivado_synthesis2-name">name</a>, <a href="#vivado_s
 | <a id="vivado_synthesis2-include_dirs"></a>include_dirs |  A list of include directories.   | List of strings | optional |  `[]`  |
 | <a id="vivado_synthesis2-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_synthesis2-part"></a>part |  The part that is targeted by this project   | String | required |  |
+| <a id="vivado_synthesis2-post_synth_design"></a>post_synth_design |  TCL commands, one per line, to add after `synth_design` command in Vivado   | List of strings | optional |  `[]`  |
+| <a id="vivado_synthesis2-synth_design_options"></a>synth_design_options |  Additional options to pass to the `synth_design` command in Vivado   | String | optional |  `""`  |
 | <a id="vivado_synthesis2-top"></a>top |  Mandatory name of the top level entity   | String | required |  |
 | <a id="vivado_synthesis2-xdcs"></a>xdcs |  Constraint files   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 

--- a/build/vivado/synth_batch.tcl.template
+++ b/build/vivado/synth_batch.tcl.template
@@ -62,7 +62,11 @@ read_xdc {{"{"}} {{- . -}} {{"}"}}
 # Set the top-level entity/module and target part
 synth_design -top {{ .Top }} -part {{ .Part }} {{range .VHDLGenerics }} \
   -generic   {{.}} {{end}} {{range .VerilogProperties }} \
-  -parameter {{.}} {{end}}
+  -parameter {{.}} {{end}} {{ .SynthDesignOptions }}
+
+{{- range .PostSynthDesign}}
+{{ . }}
+{{- end}}
 
 # Write the synthesized netlist
 write_checkpoint -force {{ .SaveDcpFile }}

--- a/integration/MODULE.bazel.lock
+++ b/integration/MODULE.bazel.lock
@@ -137,6 +137,7 @@
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
     "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
     "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
+    "https://bcr.bazel.build/modules/rules_bid/2.2.0/MODULE.bazel": "not found",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
@@ -261,6 +262,8 @@
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/bazel_registry.json": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/MODULE.bazel": "2c071c86fb07fc4dda1d12b3ede8bac669d6be58f9251ce158b37253d5fa2c0d",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/source.json": "40672e459b4f82fca2539b4f4f8d35750eb6194430ac6f1ed5d311a82cac343c",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_bid/2.2.0/MODULE.bazel": "15caebb3485cfe01409299e37dba17142ad4e783ffe6b75dd3b813b7488b26ec",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_bid/2.2.0/source.json": "74063d77fd04dca1bc333ab6a0324b6273995fe5c99f3f25dd360105874caad1",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/vhdl_ls_gen/0.2.3/MODULE.bazel": "f53100e2d74d612693c19eff3783604e0070ea15bd1eed264eecff7e1b61fe52",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/vhdl_ls_gen/0.2.3/source.json": "485e4774d64acc5556d315ff982be54c31e1502523f76574095b1ccde7bbb2fd"
   },

--- a/internal/vivado_synthesis2.bzl
+++ b/internal/vivado_synthesis2.bzl
@@ -127,6 +127,8 @@ def _vivado_synthesis2_impl(ctx):
     args.add_all(include_dirs, before_each="--include-dir")
     args.add_all(src_paths, before_each="--source")
     args.add_all(xdcs_paths, before_each="--constraints")
+    args.add("--synth-design-options", ctx.attr.synth_design_options)
+    args.add_all(ctx.attr.post_synth_design, before_each="--post-synth-design")
 
 
     part = ctx.attr.part
@@ -247,6 +249,14 @@ vivado_synthesis2 = rule(
         "include_dirs": attr.string_list(
             allow_empty = True,
             doc = "A list of include directories.",
+        ),
+        "synth_design_options": attr.string(
+            default = "",
+            doc = "Additional options to pass to the `synth_design` command in Vivado",
+        ),
+        "post_synth_design": attr.string_list(
+            default = [],
+            doc = "TCL commands, one per line, to add after `synth_design` command in Vivado",
         ),
         "_generator": attr.label(
             doc = "xprgen binary",

--- a/internal/vivado_synthesis2.md
+++ b/internal/vivado_synthesis2.md
@@ -10,7 +10,7 @@ Vivado synthesis2 rule.
 load("@rules_vivado//internal:vivado_synthesis2.bzl", "vivado_synthesis2")
 
 vivado_synthesis2(<a href="#vivado_synthesis2-name">name</a>, <a href="#vivado_synthesis2-deps">deps</a>, <a href="#vivado_synthesis2-srcs">srcs</a>, <a href="#vivado_synthesis2-data">data</a>, <a href="#vivado_synthesis2-hdrs">hdrs</a>, <a href="#vivado_synthesis2-defines">defines</a>, <a href="#vivado_synthesis2-env">env</a>, <a href="#vivado_synthesis2-generics">generics</a>, <a href="#vivado_synthesis2-include_dirs">include_dirs</a>, <a href="#vivado_synthesis2-mount">mount</a>, <a href="#vivado_synthesis2-part">part</a>,
-                  <a href="#vivado_synthesis2-top">top</a>, <a href="#vivado_synthesis2-xdcs">xdcs</a>)
+                  <a href="#vivado_synthesis2-post_synth_design">post_synth_design</a>, <a href="#vivado_synthesis2-synth_design_options">synth_design_options</a>, <a href="#vivado_synthesis2-top">top</a>, <a href="#vivado_synthesis2-xdcs">xdcs</a>)
 </pre>
 
 
@@ -31,6 +31,8 @@ vivado_synthesis2(<a href="#vivado_synthesis2-name">name</a>, <a href="#vivado_s
 | <a id="vivado_synthesis2-include_dirs"></a>include_dirs |  A list of include directories.   | List of strings | optional |  `[]`  |
 | <a id="vivado_synthesis2-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_synthesis2-part"></a>part |  The part that is targeted by this project   | String | required |  |
+| <a id="vivado_synthesis2-post_synth_design"></a>post_synth_design |  TCL commands, one per line, to add after `synth_design` command in Vivado   | List of strings | optional |  `[]`  |
+| <a id="vivado_synthesis2-synth_design_options"></a>synth_design_options |  Additional options to pass to the `synth_design` command in Vivado   | String | optional |  `""`  |
 | <a id="vivado_synthesis2-top"></a>top |  Mandatory name of the top level entity   | String | required |  |
 | <a id="vivado_synthesis2-xdcs"></a>xdcs |  Constraint files   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 


### PR DESCRIPTION
This PR adds slots for optimization directives to `synth_batch.tcl.template`, similarly to how it was done for `pnr_batch.tcl.template`.

This pull request has been created by an automated coding assistant,
with human supervision.

Prompt: similarly how in the last git commit we added a slot to specify optimization options in the pnr_batch.tcl.template, add slots for adding optimization directives to synth_batch.tcl.template