### PR TITLE
🧪 [testing improvement] Add tests for xprgen templates and fix main_test.go

### DIFF
--- a/build/vivado/bin/xprgen/BUILD.bazel
+++ b/build/vivado/bin/xprgen/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "xprgen_lib",
@@ -14,4 +14,13 @@ go_binary(
     name = "xprgen",
     embed = [":xprgen_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "xprgen_test",
+    srcs = [
+        "main_test.go",
+        "templates_test.go",
+    ],
+    embed = [":xprgen_lib"],
 )

--- a/build/vivado/bin/xprgen/main_test.go
+++ b/build/vivado/bin/xprgen/main_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"errors"
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,41 +13,41 @@ import (
 
 func TestAppendTo(t *testing.T) {
 	tests := []struct {
-		name               string
-		fl                 FileLib
-		initialSV          []FileLib
-		initialV           []FileLib
-		initialVHDL        []FileLib
-		initialOther       []FileLib
-		wantSV             []FileLib
-		wantV              []FileLib
-		wantVHDL           []FileLib
-		wantOther          []FileLib
-		wantErr            bool
+		name         string
+		fl           FileLib
+		initialSV    []FileLib
+		initialV     []FileLib
+		initialVHDL  []FileLib
+		initialOther []FileLib
+		wantSV       []FileLib
+		wantV        []FileLib
+		wantVHDL     []FileLib
+		wantOther    []FileLib
+		wantErr      bool
 	}{
 		{
-			name: "SystemVerilog file",
-			fl:   FileLib{Name: "test.sv"},
+			name:   "SystemVerilog file",
+			fl:     FileLib{Name: "test.sv"},
 			wantSV: []FileLib{{Name: "test.sv"}},
 		},
 		{
-			name: "Verilog file",
-			fl:   FileLib{Name: "test.v"},
+			name:  "Verilog file",
+			fl:    FileLib{Name: "test.v"},
 			wantV: []FileLib{{Name: "test.v"}},
 		},
 		{
-			name: "VHDL file 1",
-			fl:   FileLib{Name: "test.vhd"},
+			name:     "VHDL file 1",
+			fl:       FileLib{Name: "test.vhd"},
 			wantVHDL: []FileLib{{Name: "test.vhd"}},
 		},
 		{
-			name: "VHDL file 2",
-			fl:   FileLib{Name: "test.vhdl"},
+			name:     "VHDL file 2",
+			fl:       FileLib{Name: "test.vhdl"},
 			wantVHDL: []FileLib{{Name: "test.vhdl"}},
 		},
 		{
-			name: "Other file",
-			fl:   FileLib{Name: "test.txt"},
+			name:      "Other file",
+			fl:        FileLib{Name: "test.txt"},
 			wantOther: []FileLib{{Name: "test.txt"}},
 		},
 		{
@@ -86,16 +86,6 @@ func TestAppendTo(t *testing.T) {
 	}
 }
 
-func TestWriteFile(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	tests := []struct {
-		name    string
-		fn      string
-		tpl     *template.Template
-		xpr     *XPRBinding
-		wantErr bool
-		verify  func(t *testing.T, fn string)
 func TestRepeatedString(t *testing.T) {
 	rs := RepeatedString{}
 
@@ -133,28 +123,13 @@ func TestWriteFile(t *testing.T) {
 		xpr     *XPRBinding
 		wantErr bool
 		wantStr string
+		verify  func(t *testing.T, fn string)
 	}{
 		{
 			name: "empty filename",
 			fn:   "",
 			tpl:  template.Must(template.New("test").Parse("{{.Project}}")),
 			xpr:  &XPRBinding{Project: "test_proj"},
-		},
-		{
-			name: "successful write",
-			fn:   filepath.Join(tmpDir, "output.txt"),
-			tpl:  template.Must(template.New("test").Parse("Project: {{.Project}}")),
-			xpr:  &XPRBinding{Project: "test_proj"},
-			verify: func(t *testing.T, fn string) {
-				content, err := os.ReadFile(fn)
-				if err != nil {
-					t.Fatalf("failed to read output file: %v", err)
-				}
-				want := "Project: test_proj"
-				if string(content) != want {
-					t.Errorf("file content = %q, want %q", string(content), want)
-				}
-			},
 		},
 		{
 			name:    "create file error",
@@ -170,26 +145,29 @@ func TestWriteFile(t *testing.T) {
 			tpl:     template.Must(template.New("test").Funcs(template.FuncMap{"fail": func() (string, error) { return "", errors.New("template fail") }}).Parse("{{fail}}")),
 			xpr:     &XPRBinding{},
 			wantErr: true,
-			wantErr: false,
 		},
 		{
-			name: "success",
-			fn:   filepath.Join(tmpDir, "out.txt"),
-			xpr:  &XPRBinding{Project: "TestProj"},
+			name:    "success",
+			fn:      filepath.Join(tmpDir, "out.txt"),
+			xpr:     &XPRBinding{Project: "TestProj"},
 			wantErr: false,
 			wantStr: "Project: TestProj",
 		},
 		{
-			name: "invalid path",
-			fn:   filepath.Join(tmpDir, "nonexistent", "out.txt"),
-			wantErr: true,
-		},
-		{
-			name: "template execution error",
-			fn:   filepath.Join(tmpDir, "error.txt"),
-			tpl:  template.Must(template.New("error").Option("missingkey=error").Parse("{{.NonExistent}}")),
-			xpr:  &XPRBinding{Project: "TestProj"},
-			wantErr: true,
+			name: "successful write with verify",
+			fn:   filepath.Join(tmpDir, "output_verify.txt"),
+			tpl:  template.Must(template.New("test_verify").Parse("Project: {{.Project}}")),
+			xpr:  &XPRBinding{Project: "test_proj_verify"},
+			verify: func(t *testing.T, fn string) {
+				content, err := os.ReadFile(fn)
+				if err != nil {
+					t.Fatalf("failed to read output file: %v", err)
+				}
+				want := "Project: test_proj_verify"
+				if string(content) != want {
+					t.Errorf("file content = %q, want %q", string(content), want)
+				}
+			},
 		},
 	}
 
@@ -204,12 +182,16 @@ func TestWriteFile(t *testing.T) {
 				t.Errorf("WriteFile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if err == nil && tt.fn != "" {
-				b, err := os.ReadFile(tt.fn)
-				if err != nil {
-					t.Fatalf("failed to read file: %v", err)
-				}
-				if string(b) != tt.wantStr {
-					t.Errorf("file content = %q, want %q", string(b), tt.wantStr)
+				if tt.verify != nil {
+					tt.verify(t, tt.fn)
+				} else if tt.wantStr != "" {
+					b, err := os.ReadFile(tt.fn)
+					if err != nil {
+						t.Fatalf("failed to read file: %v", err)
+					}
+					if string(b) != tt.wantStr {
+						t.Errorf("file content = %q, want %q", string(b), tt.wantStr)
+					}
 				}
 			}
 		})
@@ -233,14 +215,14 @@ func TestRun(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "invalid flag",
-			args: []string{"--invalid-flag"},
+			name:    "invalid flag",
+			args:    []string{"--invalid-flag"},
 			wantErr: true,
 		},
 		{
-			name: "invalid library file format",
-			args: []string{"--library-file", "invalid_format"},
-			wantErr: true,
+			name:       "invalid library file format",
+			args:       []string{"--library-file", "invalid_format"},
+			wantErr:    true,
 			wantErrStr: "invalid format for library-file",
 		},
 		{
@@ -255,12 +237,6 @@ func TestRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := WriteFile(tt.fn, tt.tpl, tt.xpr)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("WriteFile() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.verify != nil {
-				tt.verify(t, tt.fn)
 			stdout := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}
 

--- a/build/vivado/bin/xprgen/templates.go
+++ b/build/vivado/bin/xprgen/templates.go
@@ -51,7 +51,7 @@ read_verilog {{with .Library }} -library {{ . }} {{- end}} {{"{"}} {{- .Name -}}
 # Verilog headers
 # Ordering is important.
 {{- range .VerilogHeaders}}
-read_verilog {{with .Library }} -library {{ . }} {{- end}} -sv {{"{"}} {{- .Name -}} {{"}"}}
+read_verilog -sv {{"{"}} {{- . -}} {{"}"}}
 {{- end}}
 
 # VHDL files

--- a/build/vivado/bin/xprgen/templates_test.go
+++ b/build/vivado/bin/xprgen/templates_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+)
+
+func TestTemplates(t *testing.T) {
+	xpr := &XPRBinding{
+		Project: "TestProject",
+		PWD:     "/tmp",
+		OutXpr:  "out.xpr",
+		Fileset: "sources_1",
+		Top:     "top",
+		VerilogProperties: []string{"DEF1", "DEF2"},
+		SystemVerilogFiles: []FileLib{
+			{Name: "sv1.sv", Library: "lib1"},
+			{Name: "sv2.sv"},
+		},
+		VerilogFiles: []FileLib{
+			{Name: "v1.v", Library: "lib2"},
+			{Name: "v2.v"},
+		},
+		VerilogHeaders: []string{"h1.vh"},
+		VHDLFiles: []FileLib{
+			{Name: "vhdl1.vhd", Library: "lib3"},
+		},
+		VerilogIncludeDirs: []string{"inc1", "inc2"},
+		XDCFiles:           []string{"con1.xdc"},
+		OtherFiles: []FileLib{
+			{Name: "other1.txt"},
+		},
+		Part: "xc7a200tfbg484-2",
+	}
+
+	tests := []struct {
+		name string
+		tpl  *template.Template
+	}{
+		{"syntTpl", syntTpl},
+		{"xprTpl", xprTpl},
+		{"pnrTpl", pnrTpl},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := tt.tpl.Execute(&buf, xpr); err != nil {
+				t.Errorf("failed to execute %s: %v", tt.name, err)
+			}
+			if buf.Len() == 0 {
+				t.Errorf("%s produced empty output", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR improves the testing of the `xprgen` tool by adding specific tests for its TCL templates and fixing existing syntax errors in `main_test.go`. It also includes a bug fix in the `xprTpl` template where `VerilogHeaders` were being incorrectly processed.

---
*PR created automatically by Jules for task [5351950325108121863](https://jules.google.com/task/5351950325108121863) started by @filmil*