### PR TITLE
⚡ use dict for seen_libraries to optimize membership check

### DIFF
--- a/internal/vivado_project.bzl
+++ b/internal/vivado_project.bzl
@@ -152,7 +152,7 @@ def _vivado_project_impl(ctx):
     hdrs_files = []
 
     # Get library deps.
-    seen_libraries = []
+    seen_libraries = {}
     for dep in ctx.attr.deps:
         # process dep deps.
         provider = dep[VivadoLibraryProvider]
@@ -160,7 +160,7 @@ def _vivado_project_impl(ctx):
         for provider_dep in provider.deps.to_list():
             lib_name = provider_dep.name
             if lib_name not in seen_libraries:
-                seen_libraries += [lib_name]
+                seen_libraries[lib_name] = True
 
                 provider_dep_files = provider_dep.files
                 for file in provider_dep_files:
@@ -170,7 +170,7 @@ def _vivado_project_impl(ctx):
 
         lib_name = provider.name
         if lib_name not in seen_libraries:
-            seen_libraries += [lib_name]
+            seen_libraries[lib_name] = True
 
             for file in provider.files:
                 inputs += [file]

--- a/internal/vivado_synthesis2.bzl
+++ b/internal/vivado_synthesis2.bzl
@@ -42,14 +42,14 @@ def _vivado_synthesis2_impl(ctx):
     inputs += [template_file]
 
     # Get library deps.
-    seen_libraries = []
+    seen_libraries = {}
     for dep in ctx.attr.deps:
         provider = dep[VivadoLibraryProvider]
 
         for provider_dep in provider.deps.to_list():
             lib_name = provider_dep.name
             if lib_name not in seen_libraries:
-                seen_libraries += [lib_name]
+                seen_libraries[lib_name] = True
 
                 provider_dep_files = provider_dep.files
                 for file in provider_dep_files:
@@ -59,7 +59,7 @@ def _vivado_synthesis2_impl(ctx):
 
         lib_name = provider.name
         if lib_name not in seen_libraries:
-            seen_libraries += [lib_name]
+            seen_libraries[lib_name] = True
 
             for file in provider.files:
                 inputs += [file]


### PR DESCRIPTION
💡 **What**: Switched `seen_libraries` from a list (`[]`) to a dictionary (`{}`) in `internal/vivado_project.bzl` and `internal/vivado_synthesis2.bzl`.

🎯 **Why**: The current implementation used a list membership check (`if lib_name not in seen_libraries`) inside nested loops over dependencies. This resulted in O(n^2) complexity for dependency processing. By switching to a dictionary, the lookup is now O(1), resulting in O(n) overall complexity.

📊 **Measured Improvement**: While a formal benchmark was impractical in this environment due to the lack of a large-scale project and network-restricted test execution, this is a well-known algorithmic improvement in Starlark. The change eliminates O(n) scans of the `seen_libraries` list for each dependency, which provides a measurable speedup as the number of dependencies grows.

---
*PR created automatically by Jules for task [3621682240411750030](https://jules.google.com/task/3621682240411750030) started by @filmil*