### PR TITLE
feat: expose Vivado version, container, and path as build setting flags

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -139,6 +139,7 @@
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
     "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
     "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
+    "https://bcr.bazel.build/modules/rules_bid/2.2.0/MODULE.bazel": "not found",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
@@ -262,7 +263,9 @@
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/bazel_registry.json": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/MODULE.bazel": "2c071c86fb07fc4dda1d12b3ede8bac669d6be58f9251ce158b37253d5fa2c0d",
-    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/source.json": "40672e459b4f82fca2539b4f4f8d35750eb6194430ac6f1ed5d311a82cac343c"
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.2.4/source.json": "40672e459b4f82fca2539b4f4f8d35750eb6194430ac6f1ed5d311a82cac343c",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_bid/2.2.0/MODULE.bazel": "15caebb3485cfe01409299e37dba17142ad4e783ffe6b75dd3b813b7488b26ec",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_bid/2.2.0/source.json": "74063d77fd04dca1bc333ab6a0324b6273995fe5c99f3f25dd360105874caad1"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {

--- a/doc.md
+++ b/doc.md
@@ -10,7 +10,7 @@ Module providing documentation helper functions.
 load("@rules_vivado//:doc.bzl", "script_cmd")
 
 script_cmd(<a href="#script_cmd-script_path">script_path</a>, <a href="#script_cmd-dir_reference">dir_reference</a>, <a href="#script_cmd-cache_dir">cache_dir</a>, <a href="#script_cmd-source_dir">source_dir</a>, <a href="#script_cmd-mounts">mounts</a>, <a href="#script_cmd-envs">envs</a>, <a href="#script_cmd-tools">tools</a>, <a href="#script_cmd-freeargs">freeargs</a>,
-           <a href="#script_cmd-workdir_name">workdir_name</a>)
+           <a href="#script_cmd-workdir_name">workdir_name</a>, <a href="#script_cmd-container">container</a>)
 </pre>
 
 Generates the command line to run a docker container.
@@ -29,6 +29,7 @@ Generates the command line to run a docker container.
 | <a id="script_cmd-tools"></a>tools |  Tools to add.   |  `None` |
 | <a id="script_cmd-freeargs"></a>freeargs |  Additional arguments to pass.   |  `[]` |
 | <a id="script_cmd-workdir_name"></a>workdir_name |  The working directory name.   |  `"/work"` |
+| <a id="script_cmd-container"></a>container |  Optional container image override. When None, the default CONTAINER is used. Pass `vivado_config(ctx).container` to honor user-supplied build setting flags.   |  `None` |
 
 **RETURNS**
 

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 
 package(default_visibility = ["//visibility:public"])
@@ -10,10 +11,34 @@ exports_files([
     "vivado_ip.sh.tpl",
 ])
 
+# Override with --//internal:vivado_version=<version>. When empty, the default
+# baked into //internal:defines.bzl is used.
+string_flag(
+    name = "vivado_version",
+    build_setting_default = "",
+)
+
+# Override with --//internal:vivado_container=<image>. When empty, derives from
+# vivado_version as "xilinx-vivado:<version>".
+string_flag(
+    name = "vivado_container",
+    build_setting_default = "",
+)
+
+# Override with --//internal:vivado_path=<path>. When empty, derives from
+# vivado_version as "/opt/Xilinx/<version>/Vivado".
+string_flag(
+    name = "vivado_path",
+    build_setting_default = "",
+)
+
 bzl_library(
     name = "defines",
     srcs = ["defines.bzl"],
-    deps = ["@rules_bid//build:rules"],
+    deps = [
+        "@bazel_skylib//rules:common_settings",
+        "@rules_bid//build:rules",
+    ],
 )
 
 bzl_library(

--- a/internal/defines.bzl
+++ b/internal/defines.bzl
@@ -1,5 +1,6 @@
 """Defines variables and functions used in Vivado rules."""
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_bid//build:rules.bzl", "run_docker_cmd")
 
 DOCKER_RUN_SCRIPT_ATTRS = {
@@ -19,11 +20,59 @@ DOCKER_RUN_SCRIPT_ATTRS = {
     ),
 }
 
-VIVADO_VERSION = "2025.1"
+DEFAULT_VIVADO_VERSION = "2025.1"
 # This needs to exist on your computer before we begin.
-CONTAINER = "xilinx-vivado:{}".format(VIVADO_VERSION)
+DEFAULT_CONTAINER = "xilinx-vivado:{}".format(DEFAULT_VIVADO_VERSION)
 # This is tied to the contents of the above CONTAINER.
-VIVADO_PATH = "/opt/Xilinx/{}/Vivado".format(VIVADO_VERSION)
+DEFAULT_VIVADO_PATH = "/opt/Xilinx/{}/Vivado".format(DEFAULT_VIVADO_VERSION)
+
+# Defaults re-exported as top-level constants so legacy call sites that do not
+# yet go through `vivado_config(ctx)` keep compiling.
+VIVADO_VERSION = DEFAULT_VIVADO_VERSION
+CONTAINER = DEFAULT_CONTAINER
+VIVADO_PATH = DEFAULT_VIVADO_PATH
+
+# Attribute set that rules must merge into their `attrs` so that
+# `vivado_config(ctx)` can read the user-supplied build setting flags.
+VIVADO_CONFIG_ATTRS = {
+    "_vivado_version_flag": attr.label(
+        default = Label("//internal:vivado_version"),
+        doc = "Build setting flag override for the Vivado version.",
+    ),
+    "_vivado_container_flag": attr.label(
+        default = Label("//internal:vivado_container"),
+        doc = "Build setting flag override for the Vivado Docker container image.",
+    ),
+    "_vivado_path_flag": attr.label(
+        default = Label("//internal:vivado_path"),
+        doc = "Build setting flag override for the Vivado install path.",
+    ),
+}
+
+def vivado_config(ctx):
+    """Resolves the Vivado configuration from build setting flags.
+
+    Falls back to DEFAULT_VIVADO_VERSION / DEFAULT_CONTAINER / DEFAULT_VIVADO_PATH
+    when a flag is left at its empty default. When only `vivado_version` is set,
+    the container image and Vivado install path are derived from it.
+
+    Args:
+      ctx: The rule context. The rule's `attrs` must include VIVADO_CONFIG_ATTRS.
+
+    Returns:
+      A struct with fields `vivado_version`, `container`, and `vivado_path`.
+    """
+    version = ctx.attr._vivado_version_flag[BuildSettingInfo].value or \
+        DEFAULT_VIVADO_VERSION
+    container = ctx.attr._vivado_container_flag[BuildSettingInfo].value or \
+        "xilinx-vivado:{}".format(version)
+    vivado_path = ctx.attr._vivado_path_flag[BuildSettingInfo].value or \
+        "/opt/Xilinx/{}/Vivado".format(version)
+    return struct(
+        vivado_version = version,
+        container = container,
+        vivado_path = vivado_path,
+    )
 
 def script_cmd(
   script_path,
@@ -35,6 +84,7 @@ def script_cmd(
   tools=None,
   freeargs=[],
   workdir_name="/work",
+  container=None,
 ):
     """Generates the command line to run a docker container.
 
@@ -48,12 +98,15 @@ def script_cmd(
       tools: Tools to add.
       freeargs: Additional arguments to pass.
       workdir_name: The working directory name.
+      container: Optional container image override. When None, the default
+        CONTAINER is used. Pass `vivado_config(ctx).container` to honor
+        user-supplied build setting flags.
 
     Returns:
       The generated command line as a string.
     """
     return run_docker_cmd(
-        CONTAINER,
+        container or CONTAINER,
         script_path,
         dir_reference,
         scratch_dir="{}:/tmp/.cache".format(cache_dir),

--- a/internal/defines.md
+++ b/internal/defines.md
@@ -10,7 +10,7 @@ Defines variables and functions used in Vivado rules.
 load("@rules_vivado//internal:defines.bzl", "script_cmd")
 
 script_cmd(<a href="#script_cmd-script_path">script_path</a>, <a href="#script_cmd-dir_reference">dir_reference</a>, <a href="#script_cmd-cache_dir">cache_dir</a>, <a href="#script_cmd-source_dir">source_dir</a>, <a href="#script_cmd-mounts">mounts</a>, <a href="#script_cmd-envs">envs</a>, <a href="#script_cmd-tools">tools</a>, <a href="#script_cmd-freeargs">freeargs</a>,
-           <a href="#script_cmd-workdir_name">workdir_name</a>)
+           <a href="#script_cmd-workdir_name">workdir_name</a>, <a href="#script_cmd-container">container</a>)
 </pre>
 
 Generates the command line to run a docker container.
@@ -29,9 +29,39 @@ Generates the command line to run a docker container.
 | <a id="script_cmd-tools"></a>tools |  Tools to add.   |  `None` |
 | <a id="script_cmd-freeargs"></a>freeargs |  Additional arguments to pass.   |  `[]` |
 | <a id="script_cmd-workdir_name"></a>workdir_name |  The working directory name.   |  `"/work"` |
+| <a id="script_cmd-container"></a>container |  Optional container image override. When None, the default CONTAINER is used. Pass `vivado_config(ctx).container` to honor user-supplied build setting flags.   |  `None` |
 
 **RETURNS**
 
 The generated command line as a string.
+
+
+<a id="vivado_config"></a>
+
+## vivado_config
+
+<pre>
+load("@rules_vivado//internal:defines.bzl", "vivado_config")
+
+vivado_config(<a href="#vivado_config-ctx">ctx</a>)
+</pre>
+
+Resolves the Vivado configuration from build setting flags.
+
+Falls back to DEFAULT_VIVADO_VERSION / DEFAULT_CONTAINER / DEFAULT_VIVADO_PATH
+when a flag is left at its empty default. When only `vivado_version` is set,
+the container image and Vivado install path are derived from it.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="vivado_config-ctx"></a>ctx |  The rule context. The rule's `attrs` must include VIVADO_CONFIG_ATTRS.   |  none |
+
+**RETURNS**
+
+A struct with fields `vivado_version`, `container`, and `vivado_path`.
 
 

--- a/internal/vivado_gui.bzl
+++ b/internal/vivado_gui.bzl
@@ -1,9 +1,10 @@
 """Vivado GUI rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_PATH",
     "DOCKER_RUN_SCRIPT_ATTRS",
+    "VIVADO_CONFIG_ATTRS",
     _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 
 def _vivado_gui_impl(ctx):
@@ -15,6 +16,7 @@ def _vivado_gui_impl(ctx):
     Returns:
       A DefaultInfo provider.
     """
+    config = _vivado_config(ctx)
     executable = ctx.actions.declare_file(ctx.label.name + ".sh")
 
     docker_run = ctx.executable._script
@@ -37,6 +39,7 @@ def _vivado_gui_impl(ctx):
         dir_reference = ".",
         cache_dir = ".vivado_gui_cache",
         freeargs = ["-it", "--net=host"],
+        container = config.container,
     )
 
     ctx.actions.expand_template(
@@ -46,7 +49,7 @@ def _vivado_gui_impl(ctx):
             "{{DOCKER_RUN_RLOCATION}}": docker_run_rlocation,
             "{{SCRIPT_RLOCATION}}": script_rlocation,
             "{{CMD}}": cmd,
-            "{{VIVADO_PATH}}": VIVADO_PATH,
+            "{{VIVADO_PATH}}": config.vivado_path,
         },
         is_executable = True,
     )
@@ -62,7 +65,7 @@ def _vivado_gui_impl(ctx):
 vivado_gui = rule(
     implementation = _vivado_gui_impl,
     executable = True,
-    attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+    attrs = DOCKER_RUN_SCRIPT_ATTRS | VIVADO_CONFIG_ATTRS | {
         "script": attr.label(
             allow_single_file = [".tcl"],
             doc = "Optional TCL script to run on startup.",

--- a/internal/vivado_ip.bzl
+++ b/internal/vivado_ip.bzl
@@ -1,9 +1,10 @@
 """Vivado IP generation rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_VERSION", "CONTAINER", "VIVADO_PATH",
     "DOCKER_RUN_SCRIPT_ATTRS",
+    "VIVADO_CONFIG_ATTRS",
     _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 load("//internal:providers.bzl",
     "VivadoLibraryProvider",
@@ -18,6 +19,7 @@ def _vivado_ip_impl(ctx):
     Returns:
       A list of providers, including DefaultInfo and VivadoLibraryProvider.
     """
+    config = _vivado_config(ctx)
     name = ctx.attr.name
     module_name = ctx.attr.module_name or name
     vlnv = ctx.attr.vlnv
@@ -70,6 +72,7 @@ def _vivado_ip_impl(ctx):
         "--net=host",
         "-e", "HOME=/work",
       ],
+      container=config.container,
     )
 
     log_file = ctx.actions.declare_file("{}.log".format(name))
@@ -82,7 +85,7 @@ def _vivado_ip_impl(ctx):
         template = ctx.file._shell_template,
         substitutions = {
             "{SCRIPT}": script,
-            "{VIVADO_PATH}": VIVADO_PATH,
+            "{VIVADO_PATH}": config.vivado_path,
             "{TCL_SCRIPT}": tcl_script.path,
             "{LOG}": log_file.path,
             "{MODULE_NAME}": module_name,
@@ -115,7 +118,7 @@ def _vivado_ip_impl(ctx):
 
 vivado_ip = rule(
     implementation = _vivado_ip_impl,
-    attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+    attrs = DOCKER_RUN_SCRIPT_ATTRS | VIVADO_CONFIG_ATTRS | {
         "vlnv": attr.string(
             mandatory = True,
             doc = "The VLNV of the IP.",

--- a/internal/vivado_library.bzl
+++ b/internal/vivado_library.bzl
@@ -1,8 +1,9 @@
 """Vivado library rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_VERSION", "CONTAINER", "VIVADO_PATH",
+    "VIVADO_CONFIG_ATTRS",
     _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 load("//internal:providers.bzl",
     "VivadoLibraryProvider",
@@ -17,6 +18,7 @@ def _vivado_library_impl(ctx):
     Returns:
       A list of providers, including DefaultInfo and VivadoLibraryProvider.
     """
+    config = _vivado_config(ctx)
     args = [] # Not using ctx.actions.args() because of the very specific scripting.
     # Process inputs to the compilation.
     inputs = []
@@ -106,6 +108,7 @@ def _vivado_library_impl(ctx):
         "--net=host",
         "-e", "HOME=/work",
       ],
+      container=config.container,
     )
 
     inputs += files
@@ -191,7 +194,7 @@ def _vivado_library_impl(ctx):
     # Special Vivado sauce.
     if ctx.attr.use_glbl:
         command = "xvlog"
-        args = ["{}/data/verilog/src/glbl.v".format(VIVADO_PATH)] + args
+        args = ["{}/data/verilog/src/glbl.v".format(config.vivado_path)] + args
 
     log_file = ctx.actions.declare_file("{}.log".format(ctx.attr.name))
     outputs += [log_file]
@@ -210,7 +213,7 @@ def _vivado_library_impl(ctx):
             {args} 2>&1 > {log} || ( cat {log} && exit 1)
         """.format(
             script=script,
-            vivado_path=VIVADO_PATH,
+            vivado_path=config.vivado_path,
             command=command,
             args=" ".join(args),
             log=log_file.path,
@@ -243,7 +246,7 @@ def _vivado_library_impl(ctx):
 
 vivado_library = rule(
     implementation = _vivado_library_impl,
-    attrs = {
+    attrs = VIVADO_CONFIG_ATTRS | {
         "srcs": attr.label_list(
             # I think that Verilog does not have libraries.
             allow_files = [ "vhd", "vhdl", "v", "sv" ],

--- a/internal/vivado_place_and_route.bzl
+++ b/internal/vivado_place_and_route.bzl
@@ -1,8 +1,9 @@
 """Vivado place and route rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_VERSION", "CONTAINER", "VIVADO_PATH",
+    "VIVADO_CONFIG_ATTRS",
     _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 load("//internal:providers.bzl",
     "VivadoGenProvider",
@@ -19,6 +20,7 @@ def _vivado_pnr_impl(ctx):
   Returns:
     A list of providers, including DefaultInfo and VivadoBitstreamProvider.
   """
+  config = _vivado_config(ctx)
   name = ctx.attr.name
   project = ctx.attr.synthesis
   provider = project[VivadoGenProvider]
@@ -77,6 +79,7 @@ def _vivado_pnr_impl(ctx):
       "--net=host",
       "-e", "HOME=/work",
     ],
+    container=config.container,
   )
 
   # Run vivado with the script in the container
@@ -117,7 +120,7 @@ def _vivado_pnr_impl(ctx):
       pnr_tcl = provider.pnr_tcl_script.path,
 
       # tools
-      vivado_path = VIVADO_PATH,
+      vivado_path = config.vivado_path,
       vivado_workdir = output_dir.path,
       script = script,
       synth_tcl = synth_tcl_script.path,
@@ -140,7 +143,7 @@ def _vivado_pnr_impl(ctx):
 
 vivado_place_and_route = rule(
     implementation = _vivado_pnr_impl,
-    attrs = {
+    attrs = VIVADO_CONFIG_ATTRS | {
         "synthesis": attr.label(
             doc = "The vivado synthesis to place and route",
             mandatory = True,

--- a/internal/vivado_place_and_route2.bzl
+++ b/internal/vivado_place_and_route2.bzl
@@ -1,9 +1,10 @@
 """Vivado place and route2 rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_VERSION", "CONTAINER", "VIVADO_PATH",
-    _script_cmd = "script_cmd",
     "DOCKER_RUN_SCRIPT_ATTRS",
+    "VIVADO_CONFIG_ATTRS",
+    _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 load("//internal:providers.bzl",
     "VivadoSynthProvider",
@@ -19,6 +20,7 @@ def _vivado_place_and_route2_impl(ctx):
     Returns:
       A list of providers, including DefaultInfo and VivadoBitstreamProvider.
     """
+    config = _vivado_config(ctx)
     args = ctx.actions.args()
     name = ctx.attr.name
     generator = ctx.attr._generator.files
@@ -103,6 +105,7 @@ def _vivado_place_and_route2_impl(ctx):
         "--net=host",
         "-e", "HOME=/work",
       ],
+      container=config.container,
     )
 
     outputs = [output_dcp_file, drc_report_file, timing_summary_file, utilization_file, bit_file]
@@ -128,7 +131,7 @@ def _vivado_place_and_route2_impl(ctx):
         """.format(
             pnr_binary=pnr_binary.path,
             script=script_file.path,
-            vivado_path=VIVADO_PATH,
+            vivado_path=config.vivado_path,
             tcl=tcl_file.path,
             cache=cache_dir.path,
             work=output_dir.path,
@@ -151,7 +154,7 @@ def _vivado_place_and_route2_impl(ctx):
 
 vivado_place_and_route2 = rule(
     implementation = _vivado_place_and_route2_impl,
-    attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+    attrs = DOCKER_RUN_SCRIPT_ATTRS | VIVADO_CONFIG_ATTRS | {
         "synthesis": attr.label(
             doc = "The mandatory synth2 target to use",
             mandatory = True,

--- a/internal/vivado_project.bzl
+++ b/internal/vivado_project.bzl
@@ -2,8 +2,9 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//internal:defines.bzl",
-    "VIVADO_VERSION", "CONTAINER", "VIVADO_PATH",
+    "VIVADO_CONFIG_ATTRS",
     _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 load("//internal:providers.bzl",
     "VivadoLibraryProvider",
@@ -18,6 +19,7 @@ def _xpr_gen(
   include_dirs,
   xpr_tcl_script,
   deps_files,
+  config,
 ):
   """Generates a Vivado project file.
 
@@ -29,6 +31,7 @@ def _xpr_gen(
     include_dirs: List of include directories.
     xpr_tcl_script: The TCL script to generate the project.
     deps_files: List of dependency files.
+    config: Resolved Vivado config returned by `vivado_config(ctx)`.
 
   Returns:
     A tuple containing the project file, all outputs, and the output directory.
@@ -63,6 +66,7 @@ def _xpr_gen(
       "--net=host",
       "-e", "HOME=/work",
     ],
+    container=config.container,
   )
 
 
@@ -106,7 +110,7 @@ def _xpr_gen(
       echo "BAZEL: Done" \
     """.format(
       script = script,
-      vivado_path = VIVADO_PATH,
+      vivado_path = config.vivado_path,
       xpr_tcl = xpr_tcl_script.path,
       xprdest = project_file.path,
       xprsrc = tmp_project_file_path,
@@ -133,6 +137,7 @@ def _vivado_project_impl(ctx):
     Returns:
       A list of providers, including DefaultInfo and VivadoGenProvider.
     """
+    config = _vivado_config(ctx)
     args = ctx.actions.args()
 
     # General setup
@@ -234,7 +239,8 @@ def _vivado_project_impl(ctx):
         mnemonic = "XPRGEN"
     )
     project, other_outputs, xpr_gen_output_dir = _xpr_gen(
-      ctx, srcs_files, hdrs_files, xdcs_files, include_dirs, xpr, deps_files)
+      ctx, srcs_files, hdrs_files, xdcs_files, include_dirs, xpr, deps_files,
+      config)
     outputs += other_outputs + [project]
 
     return [
@@ -260,7 +266,7 @@ def _vivado_project_impl(ctx):
 
 vivado_project = rule(
     implementation = _vivado_project_impl,
-    attrs = {
+    attrs = VIVADO_CONFIG_ATTRS | {
         "top_level": attr.string(
             doc = "Top level entity name",
             mandatory = True,

--- a/internal/vivado_repl.bzl
+++ b/internal/vivado_repl.bzl
@@ -1,9 +1,10 @@
 """Vivado REPL rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_PATH",
     "DOCKER_RUN_SCRIPT_ATTRS",
+    "VIVADO_CONFIG_ATTRS",
     _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 
 def _vivado_repl_impl(ctx):
@@ -15,8 +16,9 @@ def _vivado_repl_impl(ctx):
     Returns:
       A DefaultInfo provider.
     """
+    config = _vivado_config(ctx)
     executable = ctx.actions.declare_file(ctx.label.name + ".sh")
-    
+
     docker_run = ctx.executable._script
     
     # We use rlocation to find the docker_run script at runtime.
@@ -40,8 +42,9 @@ def _vivado_repl_impl(ctx):
         dir_reference = ".",
         cache_dir = ".vivado_repl_cache",
         freeargs = ["-it", "--net=host", "-e", "HOME=/work"],
+        container = config.container,
     )
-    
+
     ctx.actions.expand_template(
         template = ctx.file._template,
         output = executable,
@@ -49,7 +52,7 @@ def _vivado_repl_impl(ctx):
             "{{DOCKER_RUN_RLOCATION}}": docker_run_rlocation,
             "{{SCRIPT_RLOCATION}}": script_rlocation,
             "{{CMD}}": cmd,
-            "{{VIVADO_PATH}}": VIVADO_PATH,
+            "{{VIVADO_PATH}}": config.vivado_path,
         },
         is_executable = True,
     )
@@ -65,7 +68,7 @@ def _vivado_repl_impl(ctx):
 vivado_repl = rule(
     implementation = _vivado_repl_impl,
     executable = True,
-    attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+    attrs = DOCKER_RUN_SCRIPT_ATTRS | VIVADO_CONFIG_ATTRS | {
         "script": attr.label(
             allow_single_file = [".tcl"],
             doc = "Optional TCL script to run on startup.",

--- a/internal/vivado_simulation.bzl
+++ b/internal/vivado_simulation.bzl
@@ -1,8 +1,9 @@
 """Vivado simulation rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_VERSION", "CONTAINER", "VIVADO_PATH",
+    "VIVADO_CONFIG_ATTRS",
     _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 load("//internal:providers.bzl",
     "VivadoLibraryProvider",
@@ -17,6 +18,7 @@ def _vivado_simulation_impl(ctx):
     Returns:
       A list of providers, including DefaultInfo and OutputGroupInfo.
     """
+    config = _vivado_config(ctx)
     args = ["-debug", "typical"]
     args += ctx.attr.xelab_args
     files = []
@@ -102,6 +104,7 @@ def _vivado_simulation_impl(ctx):
         "--net=host",
         "-e", "HOME=/work",
       ],
+      container=config.container,
     )
 
     if ctx.attr.xelab_relaxed:
@@ -127,7 +130,7 @@ def _vivado_simulation_impl(ctx):
             {args} 2>&1 > {log} || ( cat {log} && exit 1 ) {suffix}
         """.format(
             script=script,
-            vivado_path=VIVADO_PATH,
+            vivado_path=config.vivado_path,
             command="xelab",
             args=" ".join(args),
             suffix=" ".join(suffix),
@@ -184,7 +187,7 @@ def _vivado_simulation_impl(ctx):
         """.format(
             prefix=" ".join(prefix),
             script=script,
-            vivado_path=VIVADO_PATH,
+            vivado_path=config.vivado_path,
             command="xsim",
             args=" ".join(args),
             log=sim_log_file.path,
@@ -222,7 +225,7 @@ def _vivado_simulation_impl(ctx):
 
 vivado_simulation = rule(
     implementation = _vivado_simulation_impl,
-    attrs = {
+    attrs = VIVADO_CONFIG_ATTRS | {
         "library": attr.label(
             doc = "The library to run the simulation from",
             providers = [VivadoLibraryProvider],

--- a/internal/vivado_synthesis.bzl
+++ b/internal/vivado_synthesis.bzl
@@ -1,9 +1,10 @@
 """Vivado synthesis rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_VERSION", "CONTAINER", "VIVADO_PATH",
-    _script_cmd = "script_cmd",
     "DOCKER_RUN_SCRIPT_ATTRS",
+    "VIVADO_CONFIG_ATTRS",
+    _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 load("//internal:providers.bzl",
     "VivadoGenProvider",
@@ -19,6 +20,7 @@ def _vivado_synthesis_impl(ctx):
   Returns:
     A list of providers, including DefaultInfo, VivadoGenProvider, and VivadoSynthProvider.
   """
+  config = _vivado_config(ctx)
   # Rule name. Must be unique.
   name = ctx.attr.name
   project = ctx.attr.project
@@ -91,6 +93,7 @@ def _vivado_synthesis_impl(ctx):
       "--net=host",
       "-e", "HOME=/work",
     ],
+    container=config.container,
   )
 
   # Run vivado with the script in the container
@@ -153,7 +156,7 @@ def _vivado_synthesis_impl(ctx):
       xpr_src = provider.xpr_file.path,
 
       # tools
-      vivado_path = VIVADO_PATH,
+      vivado_path = config.vivado_path,
       user_files_dir = ip_user_files_dir_rpath,
       script = script,
       synth_tcl = synth_tcl_script.path,
@@ -176,7 +179,7 @@ def _vivado_synthesis_impl(ctx):
 
 vivado_synthesis = rule(
     implementation = _vivado_synthesis_impl,
-    attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+    attrs = DOCKER_RUN_SCRIPT_ATTRS | VIVADO_CONFIG_ATTRS | {
         "project": attr.label(
             doc = "The Vivado project to work on",
             mandatory = True,

--- a/internal/vivado_synthesis2.bzl
+++ b/internal/vivado_synthesis2.bzl
@@ -1,9 +1,10 @@
 """Vivado synthesis2 rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_VERSION", "CONTAINER", "VIVADO_PATH",
-    _script_cmd = "script_cmd",
     "DOCKER_RUN_SCRIPT_ATTRS",
+    "VIVADO_CONFIG_ATTRS",
+    _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 load("//internal:providers.bzl",
     "VivadoLibraryProvider",
@@ -19,6 +20,7 @@ def _vivado_synthesis2_impl(ctx):
     Returns:
       A list of providers, including DefaultInfo and VivadoSynthProvider.
     """
+    config = _vivado_config(ctx)
     args = ctx.actions.args()
 
     # General setup
@@ -170,6 +172,7 @@ def _vivado_synthesis2_impl(ctx):
         "--net=host",
         "-e", "HOME=/work",
       ],
+      container=config.container,
     )
 
     inputs += [tcl_file]
@@ -192,7 +195,7 @@ def _vivado_synthesis2_impl(ctx):
                 2>&1 > {name} || (cat {name} && exit 1)
         """.format(
             script=script,
-            vivado_path=VIVADO_PATH,
+            vivado_path=config.vivado_path,
             synth_tcl=tcl_file.path,
             cache=cache_dir.path,
             work=output_dir.path,
@@ -212,7 +215,7 @@ def _vivado_synthesis2_impl(ctx):
 
 vivado_synthesis2 = rule(
     implementation = _vivado_synthesis2_impl,
-    attrs = DOCKER_RUN_SCRIPT_ATTRS | {
+    attrs = DOCKER_RUN_SCRIPT_ATTRS | VIVADO_CONFIG_ATTRS | {
         "srcs": attr.label_list(
             allow_files = True,
             doc = "The sources for the `work` library",

--- a/internal/vivado_unisims_library.bzl
+++ b/internal/vivado_unisims_library.bzl
@@ -1,8 +1,9 @@
 """Vivado unisims library rule."""
 
 load("//internal:defines.bzl",
-    "VIVADO_VERSION", "CONTAINER", "VIVADO_PATH",
+    "VIVADO_CONFIG_ATTRS",
     _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
 )
 load("//internal:providers.bzl",
     "VivadoLibraryProvider",
@@ -17,6 +18,7 @@ def _vivado_unisims_library_impl(ctx):
     Returns:
       A list of providers, including DefaultInfo and VivadoLibraryProvider.
     """
+    config = _vivado_config(ctx)
     # General
     name = ctx.attr.name
     docker_run = ctx.executable._script
@@ -47,6 +49,7 @@ def _vivado_unisims_library_impl(ctx):
         "--net=host",
         "-e", "HOME=/work",
       ],
+      container=config.container,
     )
     output_dir2 = ctx.actions.declare_directory("{}.unisims.top".format(ctx.label.name))
     outputs += [output_dir2]
@@ -105,7 +108,7 @@ def _vivado_unisims_library_impl(ctx):
             {args} 2>&1 > {log} || ( cat {log} && exit 1)
         """.format(
             script=script,
-            vivado_path=VIVADO_PATH,
+            vivado_path=config.vivado_path,
             command="vivado",
             args=" ".join(args),
             log=unisims_log.path,
@@ -130,7 +133,7 @@ vivado_unisims_library = rule(
     implementation = _vivado_unisims_library_impl,
     # Options of the compile_simlib script.
     # See: https://docs.amd.com/r/en-US/ug835-vivado-tcl-commands/compile_simlib
-    attrs = {
+    attrs = VIVADO_CONFIG_ATTRS | {
         "simulator": attr.string(
             default = "xsim",
             doc = "Name of the top level entity to simulate",


### PR DESCRIPTION
## Summary

Adds three `string_flag` build settings in `//internal` so users can
override the previously hard-coded Vivado version, Docker container
image, and Vivado install path without forking the rules:

```
bazel build //... \\
  --//internal:vivado_version=2025.2 \\
  --//internal:vivado_container=my-vivado:2025.2 \\
  --//internal:vivado_path=/opt/Xilinx/2025.2/Vivado
```

From a downstream workspace, prefix the labels with `@rules_vivado`
(e.g. `--@rules_vivado//internal:vivado_version=2025.2`).

## Behavior

- Each flag defaults to `""`. When empty, the original constant defaults
  (`2025.1`, `xilinx-vivado:2025.1`, `/opt/Xilinx/2025.1/Vivado`) remain
  in effect, so existing builds are unaffected.
- Setting only `vivado_version` cascades into derived defaults for
  `container` (`xilinx-vivado:<ver>`) and `vivado_path`
  (`/opt/Xilinx/<ver>/Vivado`).
- `script_cmd` gains an optional `container` kwarg so the docker run
  command honors the flag.
- `defines.bzl` exposes `VIVADO_CONFIG_ATTRS` and `vivado_config(ctx)`;
  every rule that previously referenced `VIVADO_PATH` / `CONTAINER` now
  resolves the value through the flags via `ctx`.
- The original `VIVADO_VERSION` / `CONTAINER` / `VIVADO_PATH` symbols
  are retained as default aliases for source compatibility.

## Test plan

- [x] `bazel build //...` succeeds
- [x] `bazel test //...` — 19/19 pass (after regenerating stardoc via
  `bazel run //internal:update` and `bazel run //:update`)
- [x] `cd integration && bazel build //...` — succeeds (full Vivado IP
  generation, synthesis, P&R, bitstream)
- [x] `bazel cquery //internal:vivado_version --//internal:vivado_version=2025.2`
  shows `BuildSettingInfo.value = "2025.2"`
- [x] Integration build with `--@rules_vivado//internal:vivado_version=2025.1`
  yields full action-cache hits, confirming the flag is wired through
  the rule analysis and value substitution is deterministic.

This pull request has been created by an automated coding assistant,
with human supervision.

Prompt:
use git worktrees for your work, and use ../ as baseline dir. I want you
to implement the following. in @internal/defines.bzl , there are
constants VIVADO_VERSION, CONTAINER, and VIVADO_PATH.  Make bazel config
flags which allow the user to set non-default values for all of them, and
modify  the constants declaration so that if any of the respective flags
are set, those values are used, and if not set, then default values
remain. Read @GEMINI.md for general instructions