### PR TITLE
fix: apply fix_vivado_view.patch to resolve snapshot and relocatability

### DIFF
--- a/build/vivado/xsim.tcl.template
+++ b/build/vivado/xsim.tcl.template
@@ -1,6 +1,7 @@
 open_vcd {{VCD_FILE}}
 # Top entity: {{TOP}}
 log_vcd [get_objects -r /* ]
+log_wave -recursive *
 run -all
 close_vcd
 exit

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -164,6 +164,7 @@ bzl_library(
     srcs = ["vivado_view.bzl"],
     deps = [
         ":defines",
+        ":providers",
     ],
 )
 

--- a/internal/providers.bzl
+++ b/internal/providers.bzl
@@ -56,3 +56,13 @@ VivadoBitstreamProvider = provider(
   },
 )
 
+
+VivadoSimulationProvider = provider(
+    "Information about the simulation step",
+    fields = {
+        "wdb": "The waveform database file",
+        "snapshot_name": "The name of the simulation snapshot",
+        "xsim_dir": "The xsim.dir directory containing the snapshot",
+    },
+)
+

--- a/internal/providers.md
+++ b/internal/providers.md
@@ -81,6 +81,27 @@ A library of files used for vivado
 | <a id="VivadoLibraryProvider-unisims_libs"></a>unisims_libs |  A boolean indicating if this library contains UNISIMs    |
 
 
+<a id="VivadoSimulationProvider"></a>
+
+## VivadoSimulationProvider
+
+<pre>
+load("@rules_vivado//internal:providers.bzl", "VivadoSimulationProvider")
+
+VivadoSimulationProvider(<a href="#VivadoSimulationProvider-wdb">wdb</a>, <a href="#VivadoSimulationProvider-snapshot_name">snapshot_name</a>, <a href="#VivadoSimulationProvider-xsim_dir">xsim_dir</a>)
+</pre>
+
+Information about the simulation step
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="VivadoSimulationProvider-wdb"></a>wdb |  The waveform database file    |
+| <a id="VivadoSimulationProvider-snapshot_name"></a>snapshot_name |  The name of the simulation snapshot    |
+| <a id="VivadoSimulationProvider-xsim_dir"></a>xsim_dir |  The xsim.dir directory containing the snapshot    |
+
+
 <a id="VivadoSynthProvider"></a>
 
 ## VivadoSynthProvider

--- a/internal/vivado_simulation.bzl
+++ b/internal/vivado_simulation.bzl
@@ -7,6 +7,7 @@ load("//internal:defines.bzl",
 )
 load("//internal:providers.bzl",
     "VivadoLibraryProvider",
+    "VivadoSimulationProvider",
 )
 
 def _vivado_simulation_impl(ctx):
@@ -216,10 +217,16 @@ def _vivado_simulation_impl(ctx):
     return [
         DefaultInfo(
           files = depset([wdb_file, vcd_file]),
+          runfiles = ctx.runfiles(files = [wdb_file, xsim_dir]),
         ),
         OutputGroupInfo(
             vcd = [vcd_file],
             wdb = [wdb_file],
+        ),
+        VivadoSimulationProvider(
+            wdb = wdb_file,
+            snapshot_name = snapshot_name,
+            xsim_dir = xsim_dir,
         ),
     ]
 

--- a/internal/vivado_view.bzl
+++ b/internal/vivado_view.bzl
@@ -1,3 +1,4 @@
+load("//internal:providers.bzl", "VivadoSimulationProvider")
 """Vivado view rule."""
 
 load("//internal:defines.bzl",
@@ -28,13 +29,22 @@ def _vivado_view_impl(ctx):
     else:
         docker_run_rlocation = ctx.workspace_name + "/" + docker_run.short_path
 
-    # Find the wdb file
+    # Find the wdb file and snapshot name
     wdb_file = None
-    if OutputGroupInfo in ctx.attr.dep:
-        if hasattr(ctx.attr.dep[OutputGroupInfo], "wdb"):
-            wdb_files = ctx.attr.dep[OutputGroupInfo].wdb.to_list()
-            if wdb_files:
-                wdb_file = wdb_files[0]
+    snapshot_name = ""
+    xsim_dir = None
+    if VivadoSimulationProvider in ctx.attr.dep:
+        prov = ctx.attr.dep[VivadoSimulationProvider]
+        wdb_file = prov.wdb
+        snapshot_name = prov.snapshot_name
+        xsim_dir = prov.xsim_dir
+    
+    if not wdb_file:
+        if OutputGroupInfo in ctx.attr.dep:
+            if hasattr(ctx.attr.dep[OutputGroupInfo], "wdb"):
+                wdb_files = ctx.attr.dep[OutputGroupInfo].wdb.to_list()
+                if wdb_files:
+                    wdb_file = wdb_files[0]
 
     if not wdb_file:
         for file in ctx.attr.dep.files.to_list():
@@ -51,7 +61,30 @@ def _vivado_view_impl(ctx):
     else:
         wdb_file_rlocation = ctx.workspace_name + "/" + wdb_file.short_path
 
+    xsim_dir_rlocation = ""
+    if xsim_dir:
+        if xsim_dir.short_path.startswith("../"):
+            xsim_dir_rlocation = xsim_dir.short_path[3:]
+        else:
+            xsim_dir_rlocation = ctx.workspace_name + "/" + xsim_dir.short_path
+
+    # Find a .wcfg file if provided in data
+    wcfg_file = None
+    for data_target in ctx.attr.data:
+        for file in data_target.files.to_list():
+            if file.extension == "wcfg":
+                wcfg_file = file
+                break
+
+    wcfg_file_rlocation = ""
+    if wcfg_file:
+        if wcfg_file.short_path.startswith("../"):
+            wcfg_file_rlocation = wcfg_file.short_path[3:]
+        else:
+            wcfg_file_rlocation = ctx.workspace_name + "/" + wcfg_file.short_path
+
     runfiles_list = [docker_run, wdb_file]
+    if xsim_dir: runfiles_list.append(xsim_dir)
     for data_target in ctx.attr.data:
         for file in data_target.files.to_list():
             runfiles_list.append(file)
@@ -72,6 +105,10 @@ def _vivado_view_impl(ctx):
             "{{DOCKER_RUN_RLOCATION}}": docker_run_rlocation,
             "{{WDB_FILE_RLOCATION}}": wdb_file_rlocation,
             "{{CMD}}": cmd,
+            "{{SNAPSHOT_NAME}}": snapshot_name,
+            "{{WCFG_FILE_RLOCATION}}": wcfg_file_rlocation,
+            "{{XSIM_DIR_RLOCATION}}": xsim_dir_rlocation,
+            "{{ARGS}}": "",
             "{{VIVADO_PATH}}": config.vivado_path,
         },
         is_executable = True,

--- a/internal/vivado_view.md
+++ b/internal/vivado_view.md
@@ -1,6 +1,6 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-Vivado view rule.
+
 
 <a id="vivado_view"></a>
 

--- a/internal/vivado_view.sh.tpl
+++ b/internal/vivado_view.sh.tpl
@@ -46,10 +46,44 @@ mkdir -p "${VIVADO_HOME_DIR}"
 chmod a+w "${VIVADO_HOME_DIR}"
 
 WDB_FILE=$(rlocation {{WDB_FILE_RLOCATION}})
-if [[ ! -f "${WDB_FILE}" ]]; then
-  echo >&2 "ERROR: Cannot find WDB file at ${WDB_FILE}"
-  exit 1
+WCFG_FILE_PATH=$(rlocation {{WCFG_FILE_RLOCATION}})
+XSIM_DIR_PATH=$(rlocation {{XSIM_DIR_RLOCATION}})
+
+# Create a writable work directory.
+WORK_DIR="${PWD}/.vivado_view_work"
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}"
+
+# Copy xsim.dir to the work directory and make it writable.
+if [[ -d "${XSIM_DIR_PATH}/xsim.dir" ]]; then
+    cp -R "${XSIM_DIR_PATH}/xsim.dir" "${WORK_DIR}/"
+    chmod -R +w "${WORK_DIR}/xsim.dir"
 fi
+
+# Copy the WDB file.
+if [[ -f "${WDB_FILE}" ]]; then
+    cp "${WDB_FILE}" "${WORK_DIR}/sim.wdb"
+fi
+
+# Copy WCFG if present.
+WCFG_IN_WORK=""
+if [[ -n "${WCFG_FILE_PATH}" && -f "${WCFG_FILE_PATH}" ]]; then
+    cp "${WCFG_FILE_PATH}" "${WORK_DIR}/view.wcfg"
+    WCFG_IN_WORK="view.wcfg"
+fi
+
+# Create the TCL script.
+cat <<TCL > "${WORK_DIR}/view.tcl"
+if { [file exists sim.wdb] } {
+    open_wave_database sim.wdb
+}
+if { "${WCFG_IN_WORK}" != "" } {
+    open_wave_config "${WCFG_IN_WORK}"
+}
+TCL
+
+# Change to the work directory.
+cd "${WORK_DIR}"
 
 ${CMD_FINAL} \
     --envs="DISPLAY=${DISPLAY},HOME=/home/vivado" \
@@ -57,6 +91,6 @@ ${CMD_FINAL} \
     -- \
     LD_LIBRARY_PATH="{{VIVADO_PATH}}/lib/lnx64.o" \
     "{{VIVADO_PATH}}/bin/setEnvAndRunCmd.sh" xsim \
-    "${WDB_FILE}" -gui {{ARGS}} "$@"
+    {{SNAPSHOT_NAME}} -gui -tclbatch view.tcl {{ARGS}} "$@"
 
 # vim: ft=bash


### PR DESCRIPTION
Applies the corrections from `fix_vivado_view.patch` to resolve non-relocatability of `xsim.dir` and ensure the correct simulation snapshot and waveform config are passed.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt:
- I have some corrections in file @~/code/hw/a200t_examples/third_party/vivado/fix_vivado_view.patch, can you apply them here
- send pr