### PR TITLE
feat(extract): add vivado_extract rule to copy files from the Vivado image

### DIFF
--- a/build/vivado/rules.bzl
+++ b/build/vivado/rules.bzl
@@ -20,6 +20,7 @@ load("//internal:vivado_ip.bzl", _vivado_ip = "vivado_ip")
 load("//internal:vivado_view.bzl", _vivado_view = "vivado_view")
 load("//internal:vivado_ila.bzl", _vivado_ila = "vivado_ila")
 load("//internal:vivado_read_ila.bzl", _vivado_read_ila = "vivado_read_ila")
+load("//internal:vivado_extract.bzl", _vivado_extract = "vivado_extract")
 
 vivado_project = _vivado_project
 vivado_synthesis = _vivado_synthesis
@@ -39,3 +40,4 @@ vivado_ip = _vivado_ip
 vivado_view = _vivado_view
 vivado_ila = _vivado_ila
 vivado_read_ila = _vivado_read_ila
+vivado_extract = _vivado_extract

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -203,6 +203,14 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "vivado_extract",
+    srcs = ["vivado_extract.bzl"],
+    deps = [
+        ":defines",
+    ],
+)
+
 stardoc(
     name = "md_defines",
     out = "gen.defines.md",
@@ -302,6 +310,13 @@ stardoc(
 )
 
 stardoc(
+    name = "md_vivado_extract",
+    out = "gen.vivado_extract.md",
+    input = "vivado_extract.bzl",
+    deps = [":vivado_extract"],
+)
+
+stardoc(
     name = "md_vivado_simulation",
     out = "gen.vivado_simulation.md",
     input = "vivado_simulation.bzl",
@@ -353,6 +368,7 @@ write_source_files(
         "vivado_gui.md": ":md_vivado_gui",
         "vivado_view.md": ":md_vivado_view",
         "vivado_ip.md": ":md_vivado_ip",
+        "vivado_extract.md": ":md_vivado_extract",
         "vivado_simulation.md": ":md_vivado_simulation",
         "vivado_test.md": ":md_vivado_test",
         "vivado_synthesis.md": ":md_vivado_synthesis",

--- a/internal/vivado_extract.bzl
+++ b/internal/vivado_extract.bzl
@@ -1,0 +1,102 @@
+"""Rule to extract files out of the Vivado Docker image.
+
+Some Vivado artifacts (for example the `hw_server` binary and the Digilent
+cable-driver shared libraries) are needed at runtime but are not meant to be
+checked into a repository. Because every `rules_vivado` action already runs
+inside the locally provided `xilinx-vivado:<version>` Docker image, those files
+are available on the image's filesystem and can be copied out as a normal Bazel
+build action. `vivado_extract` does exactly that: it declares one output per
+requested file and copies it from the container into the Bazel output tree.
+"""
+
+load("//internal:defines.bzl",
+    "DOCKER_RUN_SCRIPT_ATTRS",
+    "VIVADO_CONFIG_ATTRS",
+    _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
+)
+
+def _vivado_extract_impl(ctx):
+    """Implementation for the vivado_extract rule.
+
+    Args:
+      ctx: The rule context.
+
+    Returns:
+      A list of providers with DefaultInfo carrying the extracted files.
+    """
+    config = _vivado_config(ctx)
+    docker_run = ctx.executable._script
+
+    if not ctx.attr.files:
+        fail("vivado_extract: `files` must not be empty.")
+
+    out_files = []
+    copy_lines = []
+    for out_rel, container_path in ctx.attr.files.items():
+        out_file = ctx.actions.declare_file(out_rel)
+        out_files.append(out_file)
+
+        # Container paths starting with "/" are absolute; otherwise they are
+        # resolved relative to the Vivado install path (e.g.
+        # /opt/Xilinx/<version>/Vivado).
+        src = container_path
+        if not src.startswith("/"):
+            src = config.vivado_path + "/" + src
+
+        # The output path is relative to the exec root which is the working
+        # directory inside the container, so the copy lands in the declared
+        # Bazel output. `cp -L` dereferences symlinks; `chmod u+w` guarantees
+        # the artifact is writable regardless of the source permissions.
+        copy_lines.append("mkdir -p \"$(dirname '{dst}')\"".format(dst = out_file.path))
+        copy_lines.append("cp -L '{src}' '{dst}'".format(src = src, dst = out_file.path))
+        copy_lines.append("chmod u+w '{dst}'".format(dst = out_file.path))
+
+    # The Docker scratch mount; declared as an output so Bazel knows the action
+    # is allowed to create it (mirrors the other Vivado rules).
+    cache_dir = ctx.actions.declare_directory("_vivado_extract.cache.{}".format(ctx.label.name))
+
+    # The copy commands run as a single script *inside* the container. Writing
+    # them to a file avoids the whitespace/quoting limitations of passing a
+    # multi-command string through docker_run.
+    inner_script = ctx.actions.declare_file("{}.extract.inner.sh".format(ctx.label.name))
+    ctx.actions.write(
+        output = inner_script,
+        content = "#!/usr/bin/env bash\nset -euo pipefail\n" + "\n".join(copy_lines) + "\n",
+        is_executable = True,
+    )
+
+    script = _script_cmd(
+        docker_run.path,
+        out_files[0].path,
+        cache_dir.path,
+        freeargs = ["--net=host"],
+        container = config.container,
+    )
+
+    outputs = out_files + [cache_dir]
+    ctx.actions.run_shell(
+        progress_message = "Vivado extract %d file(s) from %s" % (len(out_files), config.container),
+        inputs = [docker_run, inner_script],
+        outputs = outputs,
+        tools = [docker_run],
+        mnemonic = "VivadoExtract",
+        command = "{script} bash {inner}".format(script = script, inner = inner_script.path),
+    )
+
+    return [DefaultInfo(files = depset(out_files))]
+
+vivado_extract = rule(
+    implementation = _vivado_extract_impl,
+    doc = "Extracts files from the Vivado Docker image into Bazel outputs.",
+    attrs = DOCKER_RUN_SCRIPT_ATTRS | VIVADO_CONFIG_ATTRS | {
+        "files": attr.string_dict(
+            mandatory = True,
+            doc = "Map of output path (relative to this package) to a path " +
+                  "inside the Vivado container. A container path starting with " +
+                  "'/' is treated as absolute; otherwise it is resolved " +
+                  "relative to the Vivado install path (e.g. " +
+                  "/opt/Xilinx/<version>/Vivado).",
+        ),
+    },
+)

--- a/internal/vivado_extract.md
+++ b/internal/vivado_extract.md
@@ -1,0 +1,35 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Rule to extract files out of the Vivado Docker image.
+
+Some Vivado artifacts (for example the `hw_server` binary and the Digilent
+cable-driver shared libraries) are needed at runtime but are not meant to be
+checked into a repository. Because every `rules_vivado` action already runs
+inside the locally provided `xilinx-vivado:<version>` Docker image, those files
+are available on the image's filesystem and can be copied out as a normal Bazel
+build action. `vivado_extract` does exactly that: it declares one output per
+requested file and copies it from the container into the Bazel output tree.
+
+<a id="vivado_extract"></a>
+
+## vivado_extract
+
+<pre>
+load("@rules_vivado//internal:vivado_extract.bzl", "vivado_extract")
+
+vivado_extract(<a href="#vivado_extract-name">name</a>, <a href="#vivado_extract-env">env</a>, <a href="#vivado_extract-files">files</a>, <a href="#vivado_extract-mount">mount</a>)
+</pre>
+
+Extracts files from the Vivado Docker image into Bazel outputs.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_extract-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_extract-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_extract-files"></a>files |  Map of output path (relative to this package) to a path inside the Vivado container. A container path starting with '/' is treated as absolute; otherwise it is resolved relative to the Vivado install path (e.g. /opt/Xilinx/<version>/Vivado).   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | required |  |
+| <a id="vivado_extract-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+
+


### PR DESCRIPTION
## Summary

Adds a generic `vivado_extract` build rule that copies files out of the
locally provided `xilinx-vivado:<version>` Docker image into Bazel outputs,
so downstream projects no longer need to check large, proprietary Vivado
artifacts (for example `hw_server` and the Digilent cable-driver `.so`
files) into git.

Refs: https://github.com/filmil/bazel_rules_vivado/issues/108

## How it works

- New `internal/vivado_extract.bzl`: declares one Bazel output per requested
  file and copies it out of the container -- the same container that every
  other rules_vivado action already runs in -- via the existing rules_bid
  `docker_run` mechanism.
- The `files` attribute maps an output path (relative to the instantiating
  package) to a path inside the container. A path starting with `/` is
  absolute; otherwise it resolves relative to the Vivado install path
  (e.g. `/opt/Xilinx/<version>/Vivado`).
- Honors the `--//internal:vivado_version` / `vivado_container` /
  `vivado_path` build settings via `vivado_config(ctx)`.
- Re-exported from `//build/vivado:rules.bzl`; bzl_library + stardoc docs
  (`internal/vivado_extract.md`) wired into `//internal:update`.

Example:

    vivado_extract(
        name = "vivado_files",
        files = {
            "bin/hw_server": "bin/unwrapped/lnx64.o/hw_server",
            "lib/libdjtg.so.2": "lib/lnx64.o/libdjtg.so.2",
        },
    )

## Validation

Used downstream to extract `hw_server` plus the seven Digilent `.so` files;
every extracted file is byte-for-byte identical (matching git blob hashes)
to the artifacts that were previously checked into git.

## Commits

- feat(extract): add vivado_extract rule to copy files from the Vivado image

This pull request has been created by an automated coding assistant,
with human supervision.

Prompt used to generate this pull request:
---
[1] the hw server at @third_party/xilinx/hw_server, dirs bin/ and lib/
depend on having these files locally; instead use the xilinx vivado docker
image to extract these files from the docker image and make them available
programmatically to the build process instead of having them sit in the git
repo

[2] if you have a plan on how to make this sort of approach broadly
available in a build rule, you can patch rules_vivado locally, and let me
know what the patch is so I can apply it to rules_vivado repo

[3] commit to rules_vivado and send PR for rules_vivado

[4] refer to bug https://github.com/filmil/bazel_rules_vivado/issues/108 in
the PR text
---
