### PR TITLE
fix(extract): add missing bzl_library dep for vivado_extract

### DIFF
--- a/build/vivado/BUILD.bazel
+++ b/build/vivado/BUILD.bazel
@@ -64,6 +64,7 @@ bzl_library(
         "//internal:vivado_view",
         "//internal:vivado_ila",
         "//internal:vivado_read_ila",
+        "//internal:vivado_extract",
     ],
 )
 

--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -2,6 +2,29 @@
 
 Vivado rules for Bazel.
 
+<a id="vivado_extract"></a>
+
+## vivado_extract
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_extract")
+
+vivado_extract(<a href="#vivado_extract-name">name</a>, <a href="#vivado_extract-env">env</a>, <a href="#vivado_extract-files">files</a>, <a href="#vivado_extract-mount">mount</a>)
+</pre>
+
+Extracts files from the Vivado Docker image into Bazel outputs.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_extract-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_extract-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="vivado_extract-files"></a>files |  Map of output path (relative to this package) to a path inside the Vivado container. A container path starting with '/' is treated as absolute; otherwise it is resolved relative to the Vivado install path (e.g. /opt/Xilinx/<version>/Vivado).   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | required |  |
+| <a id="vivado_extract-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+
+
 <a id="vivado_gui"></a>
 
 ## vivado_gui


### PR DESCRIPTION
## Summary

Fixes the broken CI build (run [27889372372](https://github.com/filmil/bazel_rules_vivado/actions/runs/27889372372)).

The recent `vivado_extract` rule was added to `build/vivado/rules.bzl`, but
the `rules` bzl_library in `build/vivado/BUILD.bazel` was never updated to
depend on `//internal:vivado_extract`. As a result the stardoc `md.extract`
target failed analysis with:

```
missing bzl_library targets for Starlark module(s) //internal:vivado_extract.bzl
```

which aborted `bazel test` and broke the workflow.

### Changes

- Add `//internal:vivado_extract` to the `rules` bzl_library deps in
  `build/vivado/BUILD.bazel`.
- Regenerate `build/vivado/rules.md` (via `bazel run //build/vivado:update`)
  so the `update_test` golden check passes; the `vivado_extract` rule is now
  documented in the generated reference.

### Notes on `bazel run //:gazelle`

Running gazelle was attempted but its `bazel_skylib` bzl plugin misbehaved on
this repo: it dropped `srcs` from the `//internal:vivado_test` bzl_library
("not found in dependency index") and did not add the `vivado_extract` dep,
leaving the build worse off. The minimal manual fix above is used instead and
matches the existing pattern (every rule loaded in `rules.bzl` has a matching
`//internal:*` dep).

### Verification

```
bazel test --test_output=errors $(bazel query "tests(//...) - tests(//build/tests/...)")
# Executed ... 25 tests pass.
```

This pull request has been created by an automated coding assistant, with
human supervision.

Prompts used:
1. "fix the build at https://github.com/filmil/bazel_rules_vivado/actions/runs/27889372372"
2. "you should be able to run \`bazel run //:gazelle\` to fix this"
3. "create the PR based on what you think should happen and we can work from there."

🤖 Generated with [Claude Code](https://claude.com/claude-code)