### PR TITLE
feat(flash): add vivado_program_flash rule for permanent QSPI programming

### DIFF
--- a/build/tests/vivado/BUILD.bazel
+++ b/build/tests/vivado/BUILD.bazel
@@ -1,6 +1,7 @@
 load(
     "//build/vivado:rules.bzl",
     "vivado_place_and_route",
+    "vivado_program_flash",
     "vivado_project",
     "vivado_synthesis",
 )
@@ -23,4 +24,19 @@ vivado_synthesis(
 vivado_place_and_route(
     name = "blinky_pnr",
     synthesis = ":blinky_synth",
+)
+
+# Program the bitstream permanently into the Alinx A200T's QSPI flash. The
+# Micron MT25QL256 (256 Mbit = 32 MB) is the flash on the AX7A200 board.
+#
+#   bazel build //build/tests/vivado:blinky_flash       # builds blinky_flash.mcs
+#   bazel run   //build/tests/vivado:blinky_flash -- \
+#       --hostport localhost:3122 \
+#       --device '*/xilinx_tcf/Digilent/<serial>'       # writes the flash
+vivado_program_flash(
+    name = "blinky_flash",
+    deps = [":blinky_pnr"],
+    flash_part = "mt25ql256-spi-x1_x2_x4",
+    interface = "SPIx4",
+    size = 32,
 )

--- a/build/vivado/BUILD.bazel
+++ b/build/vivado/BUILD.bazel
@@ -65,6 +65,7 @@ bzl_library(
         "//internal:vivado_ila",
         "//internal:vivado_read_ila",
         "//internal:vivado_extract",
+        "//internal:vivado_program_flash",
     ],
 )
 

--- a/build/vivado/bin/proggen/BUILD.bazel
+++ b/build/vivado/bin/proggen/BUILD.bazel
@@ -26,6 +26,7 @@ filegroup(
     name = "data",
     srcs = [
         "flags.yaml",
+        "flash_script.tpl.sh",
         "main_script.tpl.sh",
     ],
 )

--- a/build/vivado/bin/proggen/flash_script.tpl.sh
+++ b/build/vivado/bin/proggen/flash_script.tpl.sh
@@ -1,0 +1,178 @@
+#! /bin/bash
+# GENERATED FILE DO NOT EDIT
+#
+# Generated as:  {{ .Outfile }}
+# From template: {{ .TemplateFile }}
+#
+# Programs the device's NON-VOLATILE configuration flash (SPI/QSPI) so the
+# design loads automatically on power-up. Unlike volatile JTAG programming,
+# this persists across power cycles.
+set -eo pipefail
+
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+_log_bash_loc="$(rlocation fshlib~/log.bash)"
+if [[ "${_log_bash_loc}" == "" ]]; then
+    _log_bash_loc="$(rlocation fshlib+/log.bash)"
+    if [[ "${_log_bash_loc}" == "" ]]; then
+        echo >2 "ERROR: could not find:fshlib/log.bash"
+        exit 1
+    fi
+fi
+source "${_log_bash_loc}"
+
+readonly _this_dir="${0%/*}"
+log::debug "this_dir: ${_this_dir}"
+
+# These should be immune to path changes.
+_run_docker="$(rlocation rules_bid+/build/docker_run.sh)"
+if [[ "${_run_docker}" == "" ]]; then
+    _run_docker="$(rlocation rules_bid+/build/docker_run_/docker_run)"
+fi
+readonly _run_docker
+
+_gotopt2="$(rlocation rules_multitool~~multitool~multitool/tools/gotopt2/gotopt2)"
+if [[ "${_gotopt2}" == "" ]]; then
+    # Try for the new repo names.
+    _gotopt2="$(rlocation rules_multitool++multitool+multitool/tools/gotopt2/gotopt2)"
+    if [[ "${_gotopt2}" == "" ]]; then
+        eilo::error "gotopt2 not found"
+        exit 1
+    fi
+fi
+_yaml_config="$(rlocation bazel_rules_vivado/build/vivado/bin/proggen/flags.yaml)"
+if [[ "${_yaml_config}" == "" ]]; then
+    _yaml_config="$(rlocation rules_vivado/build/vivado/bin/proggen/flags.yaml)"
+fi
+
+readonly _mcsfile="{{ .McsFile }}"
+if [[ ! -f "${_mcsfile}" && ! -L "${_mcsfile}" ]]; then
+    echo "flash image (.mcs) not found at ${_mcsfile}"
+    ls -lR
+    exit 1
+fi
+
+readonly _flash_part="{{ .FlashPart }}"
+if [[ "${_flash_part}" == "" ]]; then
+    echo "no flash part configured (rule attribute 'flash_part' is required)"
+    exit 1
+fi
+
+GOTOPT2_OUTPUT=$(${_gotopt2} $@ <${_yaml_config})
+if [[ "$?" == "11" ]]; then
+  # When --help option is used, gotopt2 exits with code 11.
+  exit 1
+fi
+
+eval "${GOTOPT2_OUTPUT}"
+
+if [[ "${gotopt2_hostport}" == "" ]]; then
+    echo "--hostport is required, often the value should be 'localhost:3122'"
+    exit 1
+fi
+
+if [[ "${gotopt2_device}" == "" ]]; then
+    echo "--device is required"
+    exit 1
+fi
+
+readonly _tcl_script_file="prog_flash.tcl"
+# The root of the Vivado installation in the container's filesystem.
+readonly _vivado_version="{{ .VivadoVersion }}"
+readonly _vivado_root="/opt/Xilinx/${_vivado_version}/Vivado"
+
+log::debug "Creating script file: ${_tcl_script_file}"
+log::debug "Using flash image:    ${_mcsfile}"
+log::debug "Using flash part:     ${_flash_part}"
+log::debug "Using PWD:            ${PWD}"
+
+# Now, run the daemon.
+readonly _prog_runner_binary="{{ .ProgRunnerBinary }}"
+if [[ "${_prog_runner_binary}" != "" ]]; then
+    if [[ ! -x "${_prog_runner_binary}" ]]; then
+        log::error "programmer runner binary specified, but does not exist: "${_prog_runner_binary}
+        exit 1
+    fi
+    readonly _prog_runner_args="{{ .ProgRunnerArgs }}"
+    # The args must be without quotes so that the spaces are expanded.
+    log::debug "Running programmer binary: ${_prog_runner_binary} ${_prog_runner_args}"
+    "${_prog_runner_binary}" ${_prog_runner_args} &
+else
+    log::warn "No programmer binary, skipping"
+fi
+
+cat <<EOF > "${_tcl_script_file}" || log::error "Could not create the file: ${_tcl_script_file}"
+# Vivado tcl script: program the device's configuration flash (cfgmem).
+puts "INFO: Opening hardware manager"
+open_hw_manager
+
+puts "INFO: Connecting to the programming cable on ${gotopt2_hostport}"
+connect_hw_server -url ${gotopt2_hostport}
+current_hw_target [get_hw_targets $gotopt2_device]
+open_hw_target
+puts "INFO: Done connecting."
+
+set Device [lindex [get_hw_devices] 0]
+current_hw_device \$Device
+refresh_hw_device -update_hw_probes false \$Device
+
+puts "INFO: Creating configuration memory for flash part: $_flash_part"
+create_hw_cfgmem -hw_device \$Device [lindex [get_cfgmem_parts {$_flash_part}] 0]
+set Cfgmem [get_property PROGRAM.HW_CFGMEM \$Device]
+
+set_property PROGRAM.FILES [list "$_mcsfile"] \$Cfgmem
+set_property PROGRAM.ADDRESS_RANGE {use_file} \$Cfgmem
+set_property PROGRAM.BLANK_CHECK 0 \$Cfgmem
+set_property PROGRAM.ERASE 1 \$Cfgmem
+set_property PROGRAM.CFG_PROGRAM 1 \$Cfgmem
+set_property PROGRAM.VERIFY 1 \$Cfgmem
+set_property PROGRAM.CHECKSUM 0 \$Cfgmem
+
+puts "INFO: Loading configuration-memory programming bridge into the FPGA"
+create_hw_bitstream -hw_device \$Device [get_property PROGRAM.HW_CFGMEM_BITFILE \$Device]
+program_hw_devices \$Device
+refresh_hw_device \$Device
+
+puts "INFO: Programming configuration flash with: $_mcsfile"
+program_hw_cfgmem -hw_cfgmem \$Cfgmem
+puts "INFO: DONE programming configuration flash."
+
+puts "INFO: Refresh."
+refresh_hw_device \$Device
+puts "INFO: Done. Power-cycle the board to load the design from flash."
+EOF
+
+env RUNFILES_DIR="$PWD/.." \
+"${_run_docker}" \
+    --container=xilinx-vivado:${_vivado_version} \
+    --dir-reference=${PWD} \
+    --source-dir=${PWD} \
+    --mounts=/tmp/.X11-unix:/tmp/.X11-unix:ro,"${PWD}:/work:rw" \
+    --freeargs=--net=host,-e,HOME=/work,-w,/work \
+    --src-mount=/work \
+    LD_LIBRARY_PATH="${_vivado_root}/lib/lnx64.o" \
+    "${_vivado_root}/bin/setEnvAndRunCmd.sh" vivado \
+    -notrace -mode batch \
+    -source "/work/${_tcl_script_file}" | log::prefix "[vivado] " \
+    && log::info "OK" \
+    || log::error "The flash programming command failed."

--- a/build/vivado/bin/proggen/main.go
+++ b/build/vivado/bin/proggen/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"text/template"
 )
 
@@ -15,6 +16,13 @@ type Args struct {
 	RunDockerFile string
 	GotoptFile    string
 	BitFile       string
+
+	// Flash (cfgmem) programming mode. When McsFile is set, the generator
+	// emits a script that programs the device's non-volatile configuration
+	// flash with the given flash image instead of the FPGA SRAM.
+	McsFile        string
+	FlashPart      string
+	FlashInterface string
 
 	ProgRunnerArgs   string
 	ProgRunnerBinary string
@@ -31,8 +39,8 @@ func printEnv() {
 func run(args Args) error {
 	printEnv()
 
-	if args.BitFile == "" {
-		return fmt.Errorf("param --bitfile is required.")
+	if args.BitFile == "" && args.McsFile == "" {
+		return fmt.Errorf("one of --bitfile or --mcs-file is required.")
 	}
 	if args.RunDockerFile == "" {
 		return fmt.Errorf("param --run-docker is required.")
@@ -61,7 +69,7 @@ func run(args Args) error {
 	}
 	defer of.Close()
 
-	if err := tpl.ExecuteTemplate(of, "main_script.tpl.sh", &args); err != nil {
+	if err := tpl.ExecuteTemplate(of, filepath.Base(args.TemplateFile), &args); err != nil {
 		return fmt.Errorf("could not write outfile:\n\t%v:\n\t\t%w", args.Outfile, err)
 	}
 
@@ -76,6 +84,9 @@ func runCLI(cmdArgs []string) error {
 	fs.StringVar(&args.RunDockerFile, "run-docker", "", "The script for running docker")
 	fs.StringVar(&args.GotoptFile, "gotopt2", "", "the gotopt2 binary to use")
 	fs.StringVar(&args.BitFile, "bitfile", "", "")
+	fs.StringVar(&args.McsFile, "mcs-file", "", "The flash image (.mcs/.bin) to program into configuration flash")
+	fs.StringVar(&args.FlashPart, "flash-part", "", "The Vivado cfgmem part name of the target flash device")
+	fs.StringVar(&args.FlashInterface, "flash-interface", "", "The flash programming interface, e.g. SPIx4")
 	fs.StringVar(&args.ProgRunnerArgs, "prog-runner-args", "", "the arguments to invoke the runner with")
 	fs.StringVar(&args.ProgRunnerBinary, "prog-runner-binary", "", "The program runner binary")
 	fs.StringVar(&args.VivadoVersion, "vivado-version", "", "The Vivado version to use")

--- a/build/vivado/bin/proggen/main_test.go
+++ b/build/vivado/bin/proggen/main_test.go
@@ -95,6 +95,19 @@ func TestRun(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "success flash mode (mcs instead of bit)",
+			args: Args{
+				McsFile:       "test.mcs",
+				FlashPart:     "mt25ql256-spi-x1_x2_x4",
+				RunDockerFile: "docker.sh",
+				GotoptFile:    "gotopt2",
+				Outfile:       filepath.Join(tmpDir, "out5_flash.sh"),
+				TemplateFile:  templatePath,
+				VivadoVersion: "2025.1",
+			},
+			wantErr: false,
+		},
+		{
 			name: "template does not exist",
 			args: Args{
 				BitFile:       "test.bit",

--- a/build/vivado/rules.bzl
+++ b/build/vivado/rules.bzl
@@ -21,6 +21,7 @@ load("//internal:vivado_view.bzl", _vivado_view = "vivado_view")
 load("//internal:vivado_ila.bzl", _vivado_ila = "vivado_ila")
 load("//internal:vivado_read_ila.bzl", _vivado_read_ila = "vivado_read_ila")
 load("//internal:vivado_extract.bzl", _vivado_extract = "vivado_extract")
+load("//internal:vivado_program_flash.bzl", _vivado_program_flash = "vivado_program_flash")
 
 vivado_project = _vivado_project
 vivado_synthesis = _vivado_synthesis
@@ -41,3 +42,4 @@ vivado_view = _vivado_view
 vivado_ila = _vivado_ila
 vivado_read_ila = _vivado_read_ila
 vivado_extract = _vivado_extract
+vivado_program_flash = _vivado_program_flash

--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -205,6 +205,35 @@ vivado_program_device(<a href="#vivado_program_device-name">name</a>, <a href="#
 | <a id="vivado_program_device-prog_daemon_args"></a>prog_daemon_args |  The args to give to prog_daemon, subject to make var substitution   | List of strings | optional |  `[]`  |
 
 
+<a id="vivado_program_flash"></a>
+
+## vivado_program_flash
+
+<pre>
+load("@rules_vivado//build/vivado:rules.bzl", "vivado_program_flash")
+
+vivado_program_flash(<a href="#vivado_program_flash-name">name</a>, <a href="#vivado_program_flash-deps">deps</a>, <a href="#vivado_program_flash-data">data</a>, <a href="#vivado_program_flash-flash_part">flash_part</a>, <a href="#vivado_program_flash-format">format</a>, <a href="#vivado_program_flash-interface">interface</a>, <a href="#vivado_program_flash-prog_daemon">prog_daemon</a>, <a href="#vivado_program_flash-prog_daemon_args">prog_daemon_args</a>,
+                     <a href="#vivado_program_flash-size">size</a>)
+</pre>
+
+Programs a bitstream into a device's non-volatile configuration flash (SPI/QSPI) so it loads automatically on power-up. `bazel build` produces the flash image (.mcs/.bin); `bazel run` writes it to the board (requires --hostport and --device).
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_program_flash-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_program_flash-deps"></a>deps |  Exactly one target providing the bitstream to flash.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_program_flash-data"></a>data |  The list of dependencies to expand in prog_daemon_args.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_program_flash-flash_part"></a>flash_part |  The Vivado cfgmem part name of the target flash device, e.g. 'mt25ql256-spi-x1_x2_x4'. Board-specific; see `get_cfgmem_parts` in Vivado.   | String | required |  |
+| <a id="vivado_program_flash-format"></a>format |  The flash image format produced by `write_cfgmem`.   | String | optional |  `"mcs"`  |
+| <a id="vivado_program_flash-interface"></a>interface |  The flash programming interface, e.g. SPIx1/SPIx2/SPIx4.   | String | optional |  `"SPIx4"`  |
+| <a id="vivado_program_flash-prog_daemon"></a>prog_daemon |  Optional binary to start before programming (e.g. a hardware server).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_program_flash-prog_daemon_args"></a>prog_daemon_args |  Args for prog_daemon, subject to make var substitution.   | List of strings | optional |  `[]`  |
+| <a id="vivado_program_flash-size"></a>size |  The flash capacity in megabytes (MB), passed to `write_cfgmem -size`.   | Integer | required |  |
+
+
 <a id="vivado_project"></a>
 
 ## vivado_project

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -211,6 +211,15 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "vivado_program_flash",
+    srcs = ["vivado_program_flash.bzl"],
+    deps = [
+        ":defines",
+        ":providers",
+    ],
+)
+
 stardoc(
     name = "md_defines",
     out = "gen.defines.md",
@@ -317,6 +326,13 @@ stardoc(
 )
 
 stardoc(
+    name = "md_vivado_program_flash",
+    out = "gen.vivado_program_flash.md",
+    input = "vivado_program_flash.bzl",
+    deps = [":vivado_program_flash"],
+)
+
+stardoc(
     name = "md_vivado_simulation",
     out = "gen.vivado_simulation.md",
     input = "vivado_simulation.bzl",
@@ -369,6 +385,7 @@ write_source_files(
         "vivado_view.md": ":md_vivado_view",
         "vivado_ip.md": ":md_vivado_ip",
         "vivado_extract.md": ":md_vivado_extract",
+        "vivado_program_flash.md": ":md_vivado_program_flash",
         "vivado_simulation.md": ":md_vivado_simulation",
         "vivado_test.md": ":md_vivado_test",
         "vivado_synthesis.md": ":md_vivado_synthesis",

--- a/internal/vivado_program_device.bzl
+++ b/internal/vivado_program_device.bzl
@@ -36,12 +36,24 @@ def _vivado_program_device(ctx):
     generator = ctx.attr._proggen.files.to_list()[0]
 
     data = ctx.attr._data.files.to_list()
+
+    # Select the template and flag config by name. The proggen:data filegroup
+    # holds more than one template (main_script.tpl.sh for SRAM/bit programming
+    # and flash_script.tpl.sh for flash), so positional indexing is unsafe --
+    # adding a file to the filegroup shifts the positions and silently picks the
+    # wrong template.
+    tpl1 = None
+    yaml = None
+    for f in data:
+        if f.basename == "main_script.tpl.sh":
+            tpl1 = f
+        elif f.basename == "flags.yaml":
+            yaml = f
+    if tpl1 == None or yaml == None:
+        fail("vivado_program_device: could not find main_script.tpl.sh/flags.yaml in proggen data")
+
     for target in ctx.attr._tools:
         data += target.files.to_list()
-
-    # These do not seem to be stable; why?
-    tpl1 = data[1]
-    yaml = data[0]
 
 
     # Generated script file.

--- a/internal/vivado_program_flash.bzl
+++ b/internal/vivado_program_flash.bzl
@@ -1,0 +1,252 @@
+"""Rule to program a bitstream into a device's non-volatile flash.
+
+The `vivado_program_device` rule loads a bitstream into the FPGA's volatile
+configuration SRAM, which is lost on the next power cycle. `vivado_program_flash`
+instead writes the design into the board's non-volatile SPI/QSPI configuration
+flash so that the FPGA loads the design automatically at power-up -- i.e. it
+programs the device "permanently".
+
+It works in two phases:
+
+1. A hermetic build action runs Vivado's `write_cfgmem` to convert the `.bit`
+   into a flash image (`.mcs`/`.bin`) for the configured flash part. This needs
+   Vivado but no hardware, so it is a normal, cacheable Bazel build action --
+   `bazel build` on the target produces the flash image.
+2. A generated `bazel run` wrapper connects to a running hardware server and
+   erases + writes that image into the device flash via Vivado's
+   `create_hw_cfgmem` / `program_hw_cfgmem`. This needs the physical board.
+"""
+
+load("//internal:providers.bzl",
+    "VivadoBitstreamProvider",
+)
+load("//internal:defines.bzl",
+    "VIVADO_CONFIG_ATTRS",
+    _script_cmd = "script_cmd",
+    _vivado_config = "vivado_config",
+)
+
+def _vivado_program_flash_impl(ctx):
+    """Implementation for the vivado_program_flash rule.
+
+    Args:
+      ctx: The rule context.
+
+    Returns:
+      A list of providers with DefaultInfo carrying the flash image and the
+      executable programming wrapper.
+    """
+    if not ctx.attr.deps:
+        fail("vivado_program_flash: `deps` must contain exactly one target " +
+             "providing VivadoBitstreamProvider.")
+
+    config = _vivado_config(ctx)
+    docker_run = ctx.executable._script
+    bitfile = ctx.attr.deps[0][VivadoBitstreamProvider].bitstream
+
+    # --- Phase 1: build the flash image with write_cfgmem (no hardware). ---
+    mcs = ctx.actions.declare_file("{}.{}".format(ctx.attr.name, ctx.attr.format))
+    cache_dir = ctx.actions.declare_directory(
+        "_vivado_program_flash.cache.{}".format(ctx.label.name),
+    )
+
+    # write_cfgmem runs inside the container whose working directory is the exec
+    # root, so exec-root-relative paths (bitfile.path, mcs.path) resolve. The
+    # TCL braces around `up 0x0 <bit>` are required by write_cfgmem.
+    cfgmem_tcl = ctx.actions.declare_file("{}.cfgmem.tcl".format(ctx.attr.name))
+    ctx.actions.write(
+        output = cfgmem_tcl,
+        content = (
+            "write_cfgmem -force -format {fmt} -size {size} -interface {iface}" +
+            " -loadbit {{up 0x0 {bit}}} -file {mcs}\n"
+        ).format(
+            fmt = ctx.attr.format,
+            size = ctx.attr.size,
+            iface = ctx.attr.interface,
+            bit = bitfile.path,
+            mcs = mcs.path,
+        ),
+    )
+
+    script = _script_cmd(
+        docker_run.path,
+        mcs.path,
+        cache_dir.path,
+        freeargs = ["--net=host", "-e", "HOME=/work"],
+        container = config.container,
+    )
+
+    ctx.actions.run_shell(
+        progress_message = "Vivado write_cfgmem \"{}\" ({} {})".format(
+            ctx.attr.name,
+            ctx.attr.format,
+            ctx.attr.flash_part,
+        ),
+        inputs = [docker_run, cfgmem_tcl, bitfile],
+        outputs = [mcs, cache_dir],
+        tools = [docker_run],
+        mnemonic = "VivadoCfgmem",
+        command = (
+            "mkdir -p \"$(dirname {mcs})\" && " +
+            "{script} " +
+            "LD_LIBRARY_PATH=\"{vivado_path}/lib/lnx64.o\" " +
+            "{vivado_path}/bin/setEnvAndRunCmd.sh vivado " +
+            "-notrace -mode batch -source {tcl} 1>&2"
+        ).format(
+            mcs = mcs.path,
+            script = script,
+            vivado_path = config.vivado_path,
+            tcl = cfgmem_tcl.path,
+        ),
+    )
+
+    # --- Phase 2: generate the bazel-run flash programming wrapper. ---
+    gotopt2 = ctx.attr._gotopt2.files.to_list()[0]
+    generator = ctx.attr._proggen.files.to_list()[0]
+
+    data = ctx.attr._data.files.to_list()
+    yaml = None
+    template = None
+    for f in data:
+        if f.basename == "flags.yaml":
+            yaml = f
+        elif f.basename == "flash_script.tpl.sh":
+            template = f
+    if yaml == None or template == None:
+        fail("vivado_program_flash: could not find flags.yaml/flash_script.tpl.sh in proggen data")
+
+    outfile = ctx.actions.declare_file("{}.sh".format(ctx.attr.name))
+    args = ctx.actions.args()
+    args.add("--outfile", outfile.path)
+    args.add("--gotopt2", gotopt2.path)
+    args.add("--run-docker", docker_run.path)
+    args.add("--template", template.path)
+    args.add("--mcs-file", mcs.short_path)
+    args.add("--flash-part", ctx.attr.flash_part)
+    args.add("--flash-interface", ctx.attr.interface)
+    args.add("--vivado-version", config.vivado_version)
+
+    if ctx.attr.prog_daemon:
+        prog_runner_args = ctx.expand_location(
+            " ".join(ctx.attr.prog_daemon_args),
+            targets = ctx.attr.data,
+        )
+        args.add("--prog-runner-args={}".format(prog_runner_args))
+        args.add("--prog-runner-binary", ctx.files.prog_daemon[0].short_path)
+
+    ctx.actions.run(
+        inputs = [generator, gotopt2, docker_run, mcs],
+        outputs = [outfile],
+        executable = generator,
+        tools = [gotopt2, docker_run] + data,
+        arguments = [args],
+        mnemonic = "FLASHGEN",
+        progress_message = "Generating flash programming script: {}".format(outfile.path),
+    )
+
+    # --- Runfiles for the generated wrapper. ---
+    runfiles = ctx.runfiles(
+        files = [docker_run, gotopt2, yaml, mcs],
+        collect_data = True,
+    )
+    tools_files = []
+    for target in ctx.attr._tools:
+        tools_files += target.files.to_list()
+    tools_runfiles = ctx.runfiles(files = tools_files, collect_data = True)
+
+    default_runfiles = [
+        ctx.attr._script[DefaultInfo].default_runfiles,
+        ctx.attr._proggen[DefaultInfo].default_runfiles,
+        ctx.attr._data[DefaultInfo].default_runfiles,
+        ctx.attr._gotopt2[DefaultInfo].default_runfiles,
+        tools_runfiles,
+    ]
+    if ctx.attr.prog_daemon:
+        default_runfiles.append(ctx.attr.prog_daemon[DefaultInfo].default_runfiles)
+
+    runfiles = runfiles.merge_all(default_runfiles)
+
+    return [
+        DefaultInfo(
+            files = depset([mcs, outfile, yaml, gotopt2]),
+            runfiles = runfiles,
+            executable = outfile,
+        ),
+    ]
+
+vivado_program_flash = rule(
+    implementation = _vivado_program_flash_impl,
+    executable = True,
+    doc = "Programs a bitstream into a device's non-volatile configuration " +
+          "flash (SPI/QSPI) so it loads automatically on power-up. " +
+          "`bazel build` produces the flash image (.mcs/.bin); `bazel run` " +
+          "writes it to the board (requires --hostport and --device).",
+    attrs = VIVADO_CONFIG_ATTRS | {
+        "deps": attr.label_list(
+            providers = [VivadoBitstreamProvider],
+            doc = "Exactly one target providing the bitstream to flash.",
+        ),
+        "flash_part": attr.string(
+            mandatory = True,
+            doc = "The Vivado cfgmem part name of the target flash device, " +
+                  "e.g. 'mt25ql256-spi-x1_x2_x4'. Board-specific; see " +
+                  "`get_cfgmem_parts` in Vivado.",
+        ),
+        "size": attr.int(
+            mandatory = True,
+            doc = "The flash capacity in megabytes (MB), passed to " +
+                  "`write_cfgmem -size`.",
+        ),
+        "interface": attr.string(
+            default = "SPIx4",
+            doc = "The flash programming interface, e.g. SPIx1/SPIx2/SPIx4.",
+        ),
+        "format": attr.string(
+            default = "mcs",
+            values = ["mcs", "bin"],
+            doc = "The flash image format produced by `write_cfgmem`.",
+        ),
+        "prog_daemon": attr.label(
+            doc = "Optional binary to start before programming (e.g. a " +
+                  "hardware server).",
+            executable = True,
+            cfg = "host",
+        ),
+        "prog_daemon_args": attr.string_list(
+            doc = "Args for prog_daemon, subject to make var substitution.",
+        ),
+        "data": attr.label_list(
+            doc = "The list of dependencies to expand in prog_daemon_args.",
+        ),
+        "_script": attr.label(
+            default = "@rules_bid//build:docker_run",
+            executable = True,
+            cfg = "host",
+            doc = "The docker run script.",
+        ),
+        "_gotopt2": attr.label(
+            default = "@gotopt2//:bin",
+            executable = True,
+            cfg = "host",
+            doc = "The gotopt2 binary.",
+        ),
+        "_proggen": attr.label(
+            default = Label("//build/vivado/bin/proggen"),
+            executable = True,
+            cfg = "host",
+            doc = "The program that generates the programming wrapper.",
+        ),
+        "_data": attr.label(
+            default = Label("//build/vivado/bin/proggen:data"),
+            doc = "The proggen templates and flag configuration.",
+            providers = [DefaultInfo],
+        ),
+        "_tools": attr.label_list(
+            default = [
+                Label("@bazel_tools//tools/bash/runfiles"),
+                Label("@fshlib//:log"),
+            ],
+            doc = "Runtime helper dependencies.",
+        ),
+    },
+)

--- a/internal/vivado_program_flash.md
+++ b/internal/vivado_program_flash.md
@@ -1,0 +1,49 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Rule to program a bitstream into a device's non-volatile flash.
+
+The `vivado_program_device` rule loads a bitstream into the FPGA's volatile
+configuration SRAM, which is lost on the next power cycle. `vivado_program_flash`
+instead writes the design into the board's non-volatile SPI/QSPI configuration
+flash so that the FPGA loads the design automatically at power-up -- i.e. it
+programs the device "permanently".
+
+It works in two phases:
+
+1. A hermetic build action runs Vivado's `write_cfgmem` to convert the `.bit`
+   into a flash image (`.mcs`/`.bin`) for the configured flash part. This needs
+   Vivado but no hardware, so it is a normal, cacheable Bazel build action --
+   `bazel build` on the target produces the flash image.
+2. A generated `bazel run` wrapper connects to a running hardware server and
+   erases + writes that image into the device flash via Vivado's
+   `create_hw_cfgmem` / `program_hw_cfgmem`. This needs the physical board.
+
+<a id="vivado_program_flash"></a>
+
+## vivado_program_flash
+
+<pre>
+load("@rules_vivado//internal:vivado_program_flash.bzl", "vivado_program_flash")
+
+vivado_program_flash(<a href="#vivado_program_flash-name">name</a>, <a href="#vivado_program_flash-deps">deps</a>, <a href="#vivado_program_flash-data">data</a>, <a href="#vivado_program_flash-flash_part">flash_part</a>, <a href="#vivado_program_flash-format">format</a>, <a href="#vivado_program_flash-interface">interface</a>, <a href="#vivado_program_flash-prog_daemon">prog_daemon</a>, <a href="#vivado_program_flash-prog_daemon_args">prog_daemon_args</a>,
+                     <a href="#vivado_program_flash-size">size</a>)
+</pre>
+
+Programs a bitstream into a device's non-volatile configuration flash (SPI/QSPI) so it loads automatically on power-up. `bazel build` produces the flash image (.mcs/.bin); `bazel run` writes it to the board (requires --hostport and --device).
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="vivado_program_flash-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_program_flash-deps"></a>deps |  Exactly one target providing the bitstream to flash.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_program_flash-data"></a>data |  The list of dependencies to expand in prog_daemon_args.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vivado_program_flash-flash_part"></a>flash_part |  The Vivado cfgmem part name of the target flash device, e.g. 'mt25ql256-spi-x1_x2_x4'. Board-specific; see `get_cfgmem_parts` in Vivado.   | String | required |  |
+| <a id="vivado_program_flash-format"></a>format |  The flash image format produced by `write_cfgmem`.   | String | optional |  `"mcs"`  |
+| <a id="vivado_program_flash-interface"></a>interface |  The flash programming interface, e.g. SPIx1/SPIx2/SPIx4.   | String | optional |  `"SPIx4"`  |
+| <a id="vivado_program_flash-prog_daemon"></a>prog_daemon |  Optional binary to start before programming (e.g. a hardware server).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_program_flash-prog_daemon_args"></a>prog_daemon_args |  Args for prog_daemon, subject to make var substitution.   | List of strings | optional |  `[]`  |
+| <a id="vivado_program_flash-size"></a>size |  The flash capacity in megabytes (MB), passed to `write_cfgmem -size`.   | Integer | required |  |
+
+


### PR DESCRIPTION
## Summary

Adds a new `vivado_program_flash` rule that programs a bitstream **permanently**
— writing it into the device's non-volatile SPI/QSPI configuration flash so the
FPGA loads the design automatically on power-up. The existing
`vivado_program_device` rule only programs the **volatile** FPGA SRAM, which is
lost on the next power cycle.

## Design

A single executable rule with two phases:

1. **Build the flash image (no hardware).** A hermetic build action runs
   Vivado's `write_cfgmem` to convert the `.bit` into a flash image
   (`.mcs`/`.bin`) for the configured flash part. `bazel build //x:prog`
   produces the image as a cacheable artifact. Mirrors the Docker build-action
   pattern in `internal/vivado_extract.bzl`.
2. **Program the flash (needs the board).** A generated `bazel run` wrapper
   connects to a hardware server and writes the image via Vivado's
   `create_hw_cfgmem` / `program_hw_cfgmem`. Mirrors
   `internal/vivado_program_device.bzl` + the `proggen` generator.

```starlark
vivado_program_flash(
    name = "blinky_flash",
    deps = [":blinky_pnr"],                 # provides VivadoBitstreamProvider
    flash_part = "mt25ql256-spi-x1_x2_x4",  # board-specific cfgmem part
    size = 32,                              # flash capacity in MB
    interface = "SPIx4",                    # default
)
```

```
bazel build //build/tests/vivado:blinky_flash        # -> blinky_flash.mcs (no board)
bazel run   //build/tests/vivado:blinky_flash -- \
    --hostport localhost:3122 --device '*/xilinx_tcf/Digilent/<serial>'
```

## Changes

- **New** `internal/vivado_program_flash.bzl` — the rule.
- **New** `build/vivado/bin/proggen/flash_script.tpl.sh` — runtime cfgmem
  programming template.
- Extends the `proggen` generator (reused, not duplicated): new flash fields,
  selects the template by basename, accepts `--mcs-file` as an alternative to
  `--bitfile`. Adds a flash-mode unit test.
- Wires the rule into `rules.bzl`, the `rules` bzl_library, the stardoc/golden
  doc targets, and regenerates reference docs.
- Adds an Alinx A200T (Micron MT25QL256 QSPI) example under
  `build/tests/vivado`.

## Verification

The actual flash write needs the Vivado Docker image and a physical board, so
it cannot run in CI. Everything else was verified locally:

- `bazel test $(bazel query "tests(//...) - tests(//build/tests/...)")` → **26 tests pass** (incl. golden-doc + proggen tests).
- `bazel build --nobuild //build/tests/vivado:blinky_flash` → analyzes clean.
- Rendered the flash template via `proggen`: no unrendered tokens, valid bash
  syntax, and the generated TCL expands correctly (`get_cfgmem_parts {…}`,
  `PROGRAM.FILES`, `program_hw_cfgmem`, with TCL `$Device`/`{use_file}`
  preserved).

End-to-end on hardware (manual): `bazel run` the target with `--hostport` and
`--device`, then power-cycle the A200T and confirm the design loads from flash.

This pull request has been created by an automated coding assistant, with human
supervision.

Prompts used:
1. "new feature - think about how we would create a bazel rule to program a bitstream to a device permanently"
2. Clarifications selected: single rule with two phases (build `.mcs` + `bazel run` programs flash); worked example targets the Alinx A200T.

🤖 Generated with [Claude Code](https://claude.com/claude-code)