### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependenc
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
 bazel_dep(name = "fshlib", version = "0.2.7")
 bazel_dep(name = "gazelle", version = "0.51.3")
-bazel_dep(name = "gotopt2", version = "2.7.1")
+bazel_dep(name = "gotopt2", version = "2.8.3")
 bazel_dep(name = "protobuf", version = "35.1")
 bazel_dep(name = "rules_bid", version = "2.3.1")
 bazel_dep(name = "rules_go", version = "0.61.1", repo_name = "io_bazel_rules_go")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* gotopt2: 2.7.1 -> 2.8.3