### PR TITLE
feat(repl): add data and use_terminal attributes to vivado_repl

### DIFF
--- a/build/vivado/rules.md
+++ b/build/vivado/rules.md
@@ -263,7 +263,7 @@ vivado_read_ila(<a href="#vivado_read_ila-name">name</a>, <a href="#vivado_read_
 <pre>
 load("@rules_vivado//build/vivado:rules.bzl", "vivado_repl")
 
-vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>, <a href="#vivado_repl-script">script</a>)
+vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-data">data</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>, <a href="#vivado_repl-script">script</a>, <a href="#vivado_repl-use_terminal">use_terminal</a>)
 </pre>
 
 
@@ -274,9 +274,11 @@ vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="vivado_repl-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_repl-data"></a>data |  Files (or targets whose default outputs and runfiles) to make available in the REPL's working directory inside the container.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="vivado_repl-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_repl-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_repl-script"></a>script |  Optional TCL script to run on startup.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_repl-use_terminal"></a>use_terminal |  If true (default), run the container with `-it` so Vivado gets an interactive TTY. Set to false for non-interactive contexts (e.g. piped input or CI), where `-it` would fail with 'the input device is not a TTY'.   | Boolean | optional |  `True`  |
 
 
 <a id="vivado_simulation"></a>

--- a/internal/vivado_repl.bzl
+++ b/internal/vivado_repl.bzl
@@ -38,13 +38,24 @@ def _vivado_repl_impl(ctx):
         else:
             script_rlocation = ctx.workspace_name + "/" + ctx.file.script.short_path
 
+    # `data` files are placed in the runfiles tree, which is mounted into the
+    # container as the working directory, so they are available to the REPL.
+    runfiles_list += ctx.files.data
+
+    # `-it` gives docker an interactive TTY (needed for the interactive REPL),
+    # but fails when there is no TTY (e.g. piped input or CI). `use_terminal`
+    # lets callers drop it.
+    freeargs = ["--net=host", "-e", "HOME=/work"]
+    if ctx.attr.use_terminal:
+        freeargs = ["-it"] + freeargs
+
     # Generate the command using the helper.
     # We'll use a placeholder for the script path and replace it in the bash script.
     cmd = _script_cmd(
         script_path = "DOCKER_RUN_PLACEHOLDER",
         dir_reference = ".",
         cache_dir = ".vivado_repl_cache",
-        freeargs = ["-it", "--net=host", "-e", "HOME=/work"],
+        freeargs = freeargs,
         container = config.container,
     )
 
@@ -60,11 +71,18 @@ def _vivado_repl_impl(ctx):
         is_executable = True,
     )
 
+    runfiles = (
+        ctx.runfiles(files = runfiles_list)
+            .merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
+            .merge(ctx.attr._script[DefaultInfo].default_runfiles)
+    )
+    for d in ctx.attr.data:
+        runfiles = runfiles.merge(d[DefaultInfo].default_runfiles)
+
     return [
         DefaultInfo(
             executable = executable,
-            runfiles = ctx.runfiles(files = runfiles_list).merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
-              .merge(ctx.attr._script[DefaultInfo].default_runfiles),
+            runfiles = runfiles,
         ),
     ]
 
@@ -75,6 +93,19 @@ vivado_repl = rule(
         "script": attr.label(
             allow_single_file = [".tcl"],
             doc = "Optional TCL script to run on startup.",
+        ),
+        "data": attr.label_list(
+            allow_files = True,
+            doc = "Files (or targets whose default outputs and runfiles) to " +
+                  "make available in the REPL's working directory inside the " +
+                  "container.",
+        ),
+        "use_terminal": attr.bool(
+            default = True,
+            doc = "If true (default), run the container with `-it` so Vivado " +
+                  "gets an interactive TTY. Set to false for non-interactive " +
+                  "contexts (e.g. piped input or CI), where `-it` would fail " +
+                  "with 'the input device is not a TTY'.",
         ),
         "_bash_runfiles": attr.label(
             default = "@bazel_tools//tools/bash/runfiles",

--- a/internal/vivado_repl.md
+++ b/internal/vivado_repl.md
@@ -9,7 +9,7 @@ Vivado REPL rule.
 <pre>
 load("@rules_vivado//internal:vivado_repl.bzl", "vivado_repl")
 
-vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>, <a href="#vivado_repl-script">script</a>)
+vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-data">data</a>, <a href="#vivado_repl-env">env</a>, <a href="#vivado_repl-mount">mount</a>, <a href="#vivado_repl-script">script</a>, <a href="#vivado_repl-use_terminal">use_terminal</a>)
 </pre>
 
 
@@ -20,8 +20,10 @@ vivado_repl(<a href="#vivado_repl-name">name</a>, <a href="#vivado_repl-env">env
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="vivado_repl-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vivado_repl-data"></a>data |  Files (or targets whose default outputs and runfiles) to make available in the REPL's working directory inside the container.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="vivado_repl-env"></a>env |  A dictionary of env variables to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_repl-mount"></a>mount |  A dictionary of mounts to define for the run.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vivado_repl-script"></a>script |  Optional TCL script to run on startup.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="vivado_repl-use_terminal"></a>use_terminal |  If true (default), run the container with `-it` so Vivado gets an interactive TTY. Set to false for non-interactive contexts (e.g. piped input or CI), where `-it` would fail with 'the input device is not a TTY'.   | Boolean | optional |  `True`  |
 
 


### PR DESCRIPTION
## Summary

Adds two optional attributes to the `vivado_repl` rule:

- **`data`** (`label_list`) — files (or targets whose default outputs and
  runfiles) are placed in the runfiles tree, which is mounted into the
  container as the working directory, so they are available inside the REPL
  session.
- **`use_terminal`** (`bool`, default `True`) — controls whether docker runs
  with `-it`. When true (default) the container gets an interactive TTY as
  before; when false, `-it` is omitted — needed for non-interactive contexts
  (piped input, CI) where `-it` fails with `the input device is not a TTY`.

Both are optional with backward-compatible defaults, so existing `vivado_repl`
targets are unchanged.

## Implementation

Both changes live in `internal/vivado_repl.bzl`; the runtime template needs no
change.

- `-it` is part of the docker `freeargs` built at analysis time, so
  `use_terminal` simply conditions its inclusion.
- `data` files are added to the rule's runfiles (and each `data` target's
  transitive `default_runfiles` is merged), and the existing working-dir mount
  exposes them in the container.

```starlark
vivado_repl(
    name = "repl",
    data = [":constraints.xdc", ":helpers.tcl"],
    use_terminal = False,  # e.g. for piped/CI use
)
```

## Verification

Verified locally (the Vivado container itself isn't needed to check the
generated launcher):

- `bazel test $(bazel query "tests(//...) - tests(//build/tests/...)")` → **25 tests pass** (incl. golden-doc tests).
- Default target: generated `repl.sh` docker command **contains** `-it`.
- A `use_terminal = False` target: generated command **omits** `-it`.
- A `data = [...]` target: the data file is present in the launcher's runfiles
  tree (which is mounted as the container working directory).

This pull request has been created by an automated coding assistant, with human
supervision.

Prompts used:
1. "new feature, new pr: modify the vivado_repl rule to add a `data` parameter, which puts the specified target files into the sandbox; and a boolean flag `use_terminal` which is true by default and if set adds `-it` flags (so, if use_terminal = false, then the `-it` is not added)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)