### PR TITLE
fix(xvhdl/xelab): use single-dash standard flags; drop -debug typical

### DIFF
--- a/internal/vivado_ip.sh.tpl
+++ b/internal/vivado_ip.sh.tpl
@@ -48,7 +48,7 @@ if [ -n "$V_FILES" ] || [ -n "$SV_FILES" ] || [ -n "$VHDL_FILES" ]; then
     if [ -n "$VHDL_FILES" ]; then
         {SCRIPT} \
         LD_LIBRARY_PATH="{VIVADO_PATH}/lib/lnx64.o" \
-        {VIVADO_PATH}/bin/setEnvAndRunCmd.sh xvhdl --2008 \
+        {VIVADO_PATH}/bin/setEnvAndRunCmd.sh xvhdl -2008 \
             --work {MODULE_NAME}={LIBRARY_OUTPUT_DIR} $VHDL_FILES 2>&1 >> {LOG}
     fi
 else

--- a/internal/vivado_library.bzl
+++ b/internal/vivado_library.bzl
@@ -146,20 +146,20 @@ def _vivado_library_impl(ctx):
             library_type = "VHDL"
             # VHDL 2008 is used by default, use bool flag `vhdl1993 = True`
             # to revert to 1993.
-            standard_flag = ["--2008"]
+            standard_flag = ["-2008"]
             if ctx.attr.vhdl1993:
                 standard_flag = []
             if effective_standard:
                 if effective_standard in ["1993", "93"]:
-                    standard_flag = ["--93"]
+                    standard_flag = ["-93"]
                 elif effective_standard in ["1987", "87"]:
-                    standard_flag = ["--87"]
+                    standard_flag = ["-87"]
                 elif effective_standard in ["2008", "08"]:
-                    standard_flag = ["--2008"]
+                    standard_flag = ["-2008"]
                 elif effective_standard in ["2019", "19"]:
-                    standard_flag = ["--2019"]
+                    standard_flag = ["-2019"]
                 else:
-                    standard_flag = ["--{}".format(effective_standard)]
+                    standard_flag = ["-{}".format(effective_standard)]
             args += standard_flag
 
     args += ["--work", "{}={}".format(library_name, library_output_dir.path)]

--- a/internal/vivado_simulation.bzl
+++ b/internal/vivado_simulation.bzl
@@ -20,7 +20,7 @@ def _vivado_simulation_impl(ctx):
       A list of providers, including DefaultInfo and OutputGroupInfo.
     """
     config = _vivado_config(ctx)
-    args = ["-debug", "typical"]
+    args = []
     args += ctx.attr.xelab_args
     files = []
     # elaborate first

--- a/internal/vivado_test.bzl
+++ b/internal/vivado_test.bzl
@@ -25,7 +25,7 @@ def _vivado_test_impl(ctx):
       A list of providers.
     """
     # 1. Elaboration step (identical to vivado_simulation)
-    args = ["-debug", "typical"]
+    args = []
     args += ctx.attr.xelab_args
     files = []
 


### PR DESCRIPTION
## Summary

- **`vivado_library.bzl` + `vivado_ip.sh.tpl`**: xvhdl officially documents single-dash flags (`-2008`, `-2019`, etc.) per AMD UG900. The double-dash form (`--2008`) may also work but is undocumented; use the canonical form throughout.

- **`vivado_simulation.bzl` + `vivado_test.bzl`**: Remove the hardcoded `-debug typical` default from xelab args. Full waveform capture for every run significantly slows simulation and fills disk. Users who need debugging can opt in via `xelab_args = ["-debug", "typical"]`.

## References

- [AMD UG900 2025.2 — xvhdl command options](https://docs.amd.com/r/en-US/ug900-vivado-logic-simulation/xelab-xvhdl-and-xvlog-xsim-Command-Options)

## Test plan

- [ ] VHDL targets compile with `-2008` flag (no errors)
- [ ] Simulation runs without `-debug typical` by default; opt-in via `xelab_args`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LPVf4iZABru8HVptrg3aZ